### PR TITLE
adding comment about 'space gotcha' when using replica sets

### DIFF
--- a/config/mongodb.yml.example
+++ b/config/mongodb.yml.example
@@ -7,6 +7,7 @@ production:
   password:
 
 #production:
+# Beware that not having the space behind the commas will lead to parsing errors
 #  hostname: [["localhost", 27017], ["localhost", 27018], ["localhost", 27019]]
 #  database: graylog2_production
 #  authenticate: false


### PR DESCRIPTION
see recent message in mailing list to prevent confusion when using replica sets.
especially to make life easier for folks who don't have ruby as their first language.
