### PR TITLE
Prefer to use name for welcome message if name is set

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,10 @@ class User < ActiveRecord::Base
   def login=(value)
     write_attribute :login, (value ? value.downcase : nil)
   end
+  
+  def display_name
+    self.name.blank? ? self.login : self.name
+  end
 
   def email=(value)
     write_attribute :email, (value ? value.downcase : nil)

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :sidebar do %>
-  <%= render :partial => "sidebar_index", :locals => { :headline => "Welcome, <span class=\"highlighted\">#{current_user.name}</span>!" } %>
+  <%= render :partial => "sidebar_index", :locals => { :headline => "Welcome, <span class=\"highlighted\">#{current_user.display_name}</span>!" } %>
 <% end %>
 
 <%= javascript_include_tag 'messageupdater' %>


### PR DESCRIPTION
Added "display_name" method to user model which will use the user's name if it's been set, otherwise it will use the user's login.
