### PR TITLE
Adding 'oldest entry' stat to sidebar

### DIFF
--- a/app/views/messages/_sidebar_index.html.erb
+++ b/app/views/messages/_sidebar_index.html.erb
@@ -42,6 +42,7 @@ Your current time: <%= gl_date(Time.zone.now) %>
   <li>Capped to: <%= number_to_human_size(MessageCollection.storage_size) %></li>
   <li>Objects: <%= MessageCollection.count %></li>
   <li>Average object size: <%= number_to_human_size(MessageCollection.average_object_size) %></li>
+  <li>Oldest entry: <%= time_ago_in_words(Time.at(Message.first.created_at)) %></li>
 </ul>
 
 <h3>Jobs & Tasks <%= tooltip("Notifications") %></h3>


### PR DESCRIPTION
Hey,

Adding an 'oldest entry' stat to the sidebar, so it is easy to see the timespan of log entries that the current dataset contains.  I think this stat is a relavant way to communicate the size of the dataset.  

I wasn't sure of the wording, and settled on 'Oldest entry' over 'Entry timespan' and 'Log timespan', but feel free to weigh in.

Thanks,

-nick
