### PR TITLE
Adding per-stream additional columns to display GELF fields.

### DIFF
--- a/app/controllers/streams_controller.rb
+++ b/app/controllers/streams_controller.rb
@@ -161,6 +161,35 @@ class StreamsController < ApplicationController
     redirect_to settings_stream_path(@stream)
   end
 
+  def addcolumn
+    @stream.additional_columns << params[:column]
+    duplicates = @stream.additional_columns.uniq!
+
+    if duplicates
+      flash[:error] = "Column '#{params[:column]}' already exists."
+    elsif @stream.save
+      flash[:notice] = "Added additional column."
+    else
+      flash[:error] = "Could not add additional column."
+    end
+
+    redirect_to settings_stream_path(@stream)
+  end
+
+  def removecolumn
+    deleted_column = @stream.additional_columns.delete(params[:column])
+
+    if deleted_column.nil?
+      flash[:error] = "Column '#{params[:column]}' doesn't exist."
+    elsif @stream.save
+      flash[:notice] = "Removed additional column '#{params[:column]}'."
+    else
+      flash[:error] = "Could not remove column '#{params[:column]}'."
+    end
+
+    redirect_to settings_stream_path(@stream)
+  end
+
   # This should now really be changed to /update soon.
   def categorize
     @stream = Stream.find_by_id params[:stream_id]

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -26,6 +26,7 @@ class Stream
   field :last_alarm_check, :type => Integer
   field :alarm_active, :type => Boolean
   field :disabled, :type => Boolean
+  field :additional_columns, :type => Array, :default => []
 
   def self.find_by_id(_id)
     _id = $1 if /^([0-9a-f]+)-/ =~ _id

--- a/app/views/messages/_table.html.erb
+++ b/app/views/messages/_table.html.erb
@@ -1,4 +1,7 @@
-<% message_length = Setting.get_message_length(current_user) %>
+<%
+message_length = Setting.get_message_length(current_user)
+additional_columns ||= []
+%>
 
 <table class="messages<%= defined?(@inline_version) ? " messages-inline" : nil %>">
   <thead>
@@ -7,6 +10,9 @@
       <th class="messages-c-host">Host</th>
       <th class="messages-c-severity">Severity</th>
       <th class="messages-c-facility">Facility</th>
+      <% additional_columns.each do |col| %>
+      <th><%= col.titleize %></th>
+      <% end %>
       <th>Message</th>
     </tr>
   </thead>
@@ -18,6 +24,9 @@
         <td><%= message.host.blank? ? nil : h(message.host) %></td>
         <td><%= syslog_level_to_human(message.level) %></td>
         <td><%= message.facility %></td>
+        <% additional_columns.each do |col| %>
+        <td><%= message.additional_fields[col] %></td>
+        <% end %>
         <td>
           <%= message.message[0..message_length] %>
           <%=raw (message.message.length > message_length) && !defined?(dont_show_links) ? "<span class='light'>...</span>" : nil %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -25,5 +25,7 @@
 
   <br style="clear: both;" />
 
-  <%= render :partial => "messages/table", :locals => { :messages => @messages, :total_messages => @total_count } %>
+  <%= render :partial => "messages/table", :locals => { :messages => @messages,
+                                                        :total_messages => @total_count,
+                                                        :additional_columns => @stream ? @stream.additional_columns : [] } %>
 </div>

--- a/app/views/streams/settings.html.erb
+++ b/app/views/streams/settings.html.erb
@@ -62,6 +62,32 @@ of the alarm. You can also define that all users are alarmed, no matter what the
 <% end %>
 <br />
 
+<h2>Additional Columns</h2>
+<div class="short-description">Add additional columns to display GELF message fields.</div>
+<ul>
+<% if @stream.additional_columns.empty? %>
+  <li><h3>No additional columns configured.</h3></li>
+<% else %>
+  <% @stream.additional_columns.each do |col| %>
+  <li>
+    <h3 style="display: inline;"><%= col %></h3>
+    <%= link_to "Delete", removecolumn_stream_path(:stream_id => @stream, :column => col),
+                          :method => :delete,
+                          :confirm => "Really delete this column?" %>
+  </li>
+  <% end %>
+<% end %>
+</ul>
+
+<%= form_tag addcolumn_stream_path(:stream_id => @stream) do %>
+  <%= label_tag 'column', 'New column:' %>
+  <%= text_field_tag 'column' %>
+  <%= hidden_field_tag :stream_id, @stream.id %>
+  <%= submit_tag 'Add' %>
+<% end %>
+
+<br/><br/>
+
 <% if Configuration.allow_deleting %>
 <%= awesome_link "Delete all messages hit by this stream", deletebystream_messages_path(:stream_id => @stream.id), :confirm => "Really delete the messages?", :method => :post %>
 <br /><br />

--- a/config/authorization_rules.rb
+++ b/config/authorization_rules.rb
@@ -33,7 +33,9 @@ authorization do
       :rename,
       :categorize,
       :clone,
-      :toggledisabled
+      :toggledisabled,
+      :addcolumn,
+      :removecolumn
     ]
     has_permission_on :streamrules, :to => [:create, :destroy]
     has_permission_on :streamcategories, :to => [:create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,8 @@ Graylog2WebInterface::Application.routes.draw do
       post :subscribe
       post :unsubscribe
       post :categorize
+      post :addcolumn
+      delete :removecolumn
     end
   end
 

--- a/test/functional/streams_controller_test.rb
+++ b/test/functional/streams_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class StreamsControllerTest < ActionController::TestCase
 
   context "creating" do
-    
+
     should "create and redirect" do
       assert_difference('Stream.count') do
         post :create, :stream => { :title => 'foo' }
@@ -81,6 +81,52 @@ class StreamsControllerTest < ActionController::TestCase
 
       assert_equal "MAMA", assigns(:new_stream).title
       assert_equal stream.streamrules, assigns(:new_stream).streamrules
+    end
+
+  end
+
+  context "columns" do
+
+    should "add a new column" do
+      stream = Stream.make
+      post :addcolumn, :id => stream.to_param, :column => "MAMA"
+      assert_response :redirect
+      assert_not_nil flash[:notice]
+
+      assert_equal "MAMA", assigns(:stream).additional_columns.first
+    end
+
+    should "not add a new column twice" do
+      stream = Stream.make
+      post :addcolumn, :id => stream.to_param, :column => "MAMA"
+      post :addcolumn, :id => stream.to_param, :column => "MAMA"
+
+      assert_not_nil flash[:error]
+
+      assert_equal 1, assigns(:stream).additional_columns.count
+    end
+
+    should "remove a column" do
+      stream = Stream.make
+      stream.additional_columns << "MAMA"
+      stream.save!
+
+      delete :removecolumn, :id => stream.to_param, :column => "MAMA"
+
+      assert_response :redirect
+      assert_not_nil flash[:notice]
+
+      assert_equal 0, assigns(:stream).additional_columns.count
+    end
+
+    should "remove a non-existant column" do
+      stream = Stream.make
+      stream.additional_columns << "MAMA"
+      stream.save!
+
+      delete :removecolumn, :id => stream.to_param, :column => "PAPA"
+
+      assert_not_nil flash[:error]
     end
 
   end

--- a/test/unit/stream_test.rb
+++ b/test/unit/stream_test.rb
@@ -18,6 +18,11 @@ class StreamTest < ActiveSupport::TestCase
       end
     end
 
+    should "have additional_columns field" do
+      stream = Stream.make
+      assert_equal stream.additional_columns, []
+    end
+
     context "disabling streams" do
 
       should "append disabled hint after title if stream is disabled" do


### PR DESCRIPTION
Custom GELF fields are one of the more powerful parts of Graylog2, and they should be highlighted.  This change allows the user to optionally specify additions columns for the messages table display so the GELF fields are visible.

In my use-case, I have a 'production warnings' stream that collects warnings from a number of different production services, and I want to be able to view which service is emitting the errors at a glance.

Feel free to change anything, ask me to change anything, or brain-storm further.

Thanks!
