### PR TITLE
Adding stream title to dashboard.

### DIFF
--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -20,6 +20,11 @@
     <div id="top-timestamp">
       <%= Time.now %>
     </div>
+    <% if @stream_title %>
+    <div id="top-title">
+      <%= @stream_title %>
+    </div>
+    <% end %>
   </div>
 
   <div id="statuscontainer" class="status-<%=h @message_count > @max_messages ? 'problems' : 'okay' %>">

--- a/public/stylesheets/dashboard.css
+++ b/public/stylesheets/dashboard.css
@@ -29,6 +29,14 @@ th {
     color: #444;
 }
 
+#top-title {
+    float: left;
+    font-size: 17px;
+    margin-top: 40px;
+    color: #444;
+    margin-left: 15px;
+}
+
 #statuscontainer {
     width: 100%;
     color: #fff;


### PR DESCRIPTION
Adding the stream title to the dashboard page, to add a little context.  I'd like to add the stream description and and a trend-line, but this simple fix fits easily with the existing UI and gives some context beyond the URL.

Tweak as needed.  Thanks!
