### PR TITLE
Disable verbose logs from Rack::Cache

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -8,6 +8,7 @@ Graylog2WebInterface::Application.configure do
   # Full error reports are disabled and caching is turned on
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
+  config.action_dispatch.rack_cache = {:metastore => "rails:/", :entitystore => "rails:/", :verbose => false}
 
   # Specifies the header that your server uses for sending files
   config.action_dispatch.x_sendfile_header = "X-Sendfile"


### PR DESCRIPTION
like:

```
cache: [POST /health/currentthroughput] invalidate, pass
cache: [POST /health/currentmqsize] invalidate, pass
```
