### PR TITLE
Let user hit enter key when focus is on remember me checkbox to login

### DIFF
--- a/public/javascripts/login.js
+++ b/public/javascripts/login.js
@@ -17,7 +17,7 @@ $(document).ready(function(){
       $("#loginform").submit();
     });
 
-    $(".login-credentials").bind("keypress", function(e) {
+    $(".login-credentials, #remember_me").bind("keypress", function(e) {
       code = (e.keyCode ? e.keyCode : e.which);
       if (code == 13) {
         $("#loginform").submit();


### PR DESCRIPTION
Currently, if the focus is on the remember me checkbox, hitting the enter key will do nothing.  I often tab from the password field to the remember me box, hit space to enable the checkbox, and then I want to be able to hit enter to login.
