### PR TITLE
Make it possible to turn off the message stats.

### DIFF
--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -37,6 +37,10 @@ class Configuration
     general_config :date_format, "%d.%m.%Y - %H:%M:%S"
   end
 
+  def self.hide_message_stats?
+    general_config :hide_message_stats, false
+  end
+
   def self.hoptoad_config(key, default = nil)
     nested_general_config :hoptoad, key, default
   end
@@ -88,7 +92,7 @@ class Configuration
       @email_config[Rails.env]
     end
   end
-  
+
   def self.indexer_config(key = nil, default = nil)
     if key
       config_value @indexer_config, Rails.env, key, default
@@ -117,7 +121,7 @@ class Configuration
   def self.indexer_host
     indexer_config :url
   end
-  
+
   def self.indexer_index_name
     indexer_config :index_name
   end

--- a/app/views/messages/_message_table_header.erb
+++ b/app/views/messages/_message_table_header.erb
@@ -4,6 +4,7 @@
   <%= render :partial => "version_check" %>
 <% end %>
 
+<% unless ::Configuration.hide_message_stats? %>
 Currently containing <span class="highlighted"><%= number_with_delimiter(@total_count, :delimiter => '.') %></span> messages.
 
 <% if @total_count > 0 %>
@@ -15,5 +16,6 @@ Stored <span class="highlighted">
   <%= number_with_delimiter(MessageCount.total_count_of_last_minutes(Setting.get_message_count_interval(current_user)), :delimiter => '.') %>
 </span>
 messages in the last <%= message_count_interval %> minutes.
+<% end %>
 
 <br />

--- a/config/general.yml.example
+++ b/config/general.yml.example
@@ -4,6 +4,7 @@ general:
   allow_deleting: false # Allowing deleting of messages negatively impacts performance
   allow_version_check: true # Enables manual (/versioncheck/index) and automatic (every 30min from overview page) version checking against graylog2.org via HTTP. 
   # custom_cookie_name: graylog2_staging1 # Set an own cookie name - Useful for multiple deployments on same host like example.org/staging1/graylog2, example.org/staging2/graylog2
+  # hide_message_stats: false # Hide the message statistics at the top of the messages page.
 
 # Settings for stream subscription emails. 
 subscriptions:


### PR DESCRIPTION
Not 100% sure if this is generally useful. But...

Been getting some performance issues on the messages page and as finding that last message is [quite expensive](http://www.elasticsearch.org/guide/reference/api/search/sort.html) ("When sorting, the relevant sorted field values are loaded into memory...").

Turns out that take a while if you have 38million messages.

Cheers,
Chris
