### PR TITLE
Wrap 'message' and 'full_message' in <pre> element to accurately represent whitespace.

### DIFF
--- a/app/views/messages/_full_message.html.erb
+++ b/app/views/messages/_full_message.html.erb
@@ -13,7 +13,8 @@
   </span>
 </h2>
 
-<pre class="messages-show-message"><%= @message.message %></pre>
+<% elem = (@message.message.include? "\n") ? "pre" : "p" %>
+<<%= elem %> class="messages-show-message"><%= @message.message %></<%= elem %>>
 
 <div id="messages-show-terms-modal" style="display: none;">
   <h2>Terms of message <span class="highlighted"><%= @message.id %></span></h2>
@@ -53,7 +54,8 @@
 
 <% unless @message.full_message.blank? %>
   <h3>Full message:</h3>
-  <pre class="messages-show-message messages-full-message"><%= @message.full_message %></pre>
+  <% elem = (@message.full_message.include? "\n") ? "pre" : "p" %>
+  <<%= elem %> class="messages-show-message messages-full-message"><%= @message.full_message %></<%= elem %>>
 <% end %>
 
 <% unless @message.streams.blank? %>


### PR DESCRIPTION
I made this change to resolve two issues with using paragraph elements to contain the message and full_message:
- multi-line short messages are difficult to understand when displayed as a space-delimited single line of text
- indented full_messages (e.g. tracebacks) are difficult to understand when the leading white-space is removed
