### PR TITLE
JS parseInt bugfix/improvement

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -64,7 +64,7 @@ $(document).ready(function(){
 
     // Stream Quick chooser
     $('#favoritestreamchooser_id').bind('change', function() {
-       window.location = "/streams/show/" + parseInt(this.value);
+       window.location = "/streams/show/" + parseInt(this.value, 10);
     });
 
     // Quickfilter
@@ -86,8 +86,8 @@ $(document).ready(function(){
     });
 
     // Full message view resizing.
-    $('#messages-show-message-full').css('width', parseInt($('#content').css('width'))-15);
-    $('#messages-show-message-full').css('height', parseInt($('#messages-show-message-full').css('height'))+10);
+    $('#messages-show-message-full').css('width', parseInt($('#content').css('width'))-15, 10);
+    $('#messages-show-message-full').css('height', parseInt($('#messages-show-message-full').css('height'))+10, 10);
 
     // Visuals: Message spread permalink
     $('#visuals-spread-hosts-permalink-link').bind('click', function() {
@@ -100,7 +100,7 @@ $(document).ready(function(){
     // Visuals: Update of new messages graph.
     $('#analytics-new-messages-update-submit').bind('click', function() {
       i = $('#analytics-new-messages-update-range');
-      v = parseInt(i.val());
+      v = parseInt(i.val(), 10);
       
       if (v <= 0) {
         return false;

--- a/public/javascripts/shell.js
+++ b/public/javascripts/shell.js
@@ -90,7 +90,7 @@ var Shell = new function() {
   }
 
   var resize_cmd = function() {
-    container_width = parseInt($('#shell-container').css('width'));
+    container_width = parseInt($('#shell-container').css('width'), 10);
     _cmd.css("width", container_width-_uprompt.width()-30);
   }
 
@@ -154,7 +154,7 @@ var Shell = new function() {
             x += "No matches.";
           } else {
             for (key in res.result) {
-              x += htmlEncode(res.result[key]["distinct"]) + "(" + parseInt(res.result[key]["count"]) + "), ";
+              x += htmlEncode(res.result[key]["distinct"]) + "(" + parseInt(res.result[key]["count"], 10) + "), ";
             }
             x = x.substring(0, x.length - 2); // Remove last comma and whitespace.
             x += "</span>"


### PR DESCRIPTION
I would be very happy if you could give me a review soon. Thanks!

parseInt(input, [radix]) without a radix can behave in several ways
- if a leading zero is provided the radix will be automatically 8 (Octal)
- if the input is prefixed with 0x the radix will be set to 16 (Hexadecimal)

All other values will have a radix by 10 (Decimal) automatically.

In order to improve readability of the code and to add predictable behaviour to the
application the radix is explicit set to radix 10 (Decimal) now.
