### PR TITLE
Produce correct query string in Quicksearch on specific setup.

### DIFF
--- a/app/models/message_gateway.rb
+++ b/app/models/message_gateway.rb
@@ -108,7 +108,7 @@ class MessageGateway
       query do
         boolean do
           # Short message
-          must { string("message:#{filters[:message]}") } unless filters[:message].blank?
+          must { string("#{filters[:message]}") } unless filters[:message].blank?
 
           # Facility
           must { term(:facility, filters[:facility]) } unless filters[:facility].blank?


### PR DESCRIPTION
This produces correct query strings in my settings with:
Ruby 1.8.7,
Rails 2.3,
Graylog2 0.9.6.

Before this i had no return value for the query ...{"query":"message:fcgi"}}..., now it is simply ...{"query":"fcgi"}}...
