### PR TITLE
insulate web interface against bogus timestamps in the datastore

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -4,11 +4,15 @@ class Message
   ADDITIONAL_FIELD_SEPARATOR = '_'
   RESERVED_ADDITIONAL_FIELDS = %w(_type _index _version)
 
-  @fields = [ :id, :message, :full_message, :created_at, :facility, :level, :host, :file, :line, :deleted, :streams ]
+  @fields = [ :id, :message, :full_message, :facility, :level, :host, :file, :line, :deleted, :streams ]
   @fields.each { |f| attr_accessor(f) }
 
   attr_accessor :plain, :total_result_count
 
+  def initialize
+    @created_at = 0
+  end
+  
   def self.parse_from_elastic(x)
     m = self.new
 
@@ -120,6 +124,19 @@ class Message
     return false
   end
 
+  def created_at
+    @created_at || 0
+  end
+  
+  def created_at=(t)
+    t ||= 0
+    begin
+      @created_at = Time.at(t).to_i
+    rescue RangeError
+      @created_at = 0
+    end  
+  end
+  
   def uniform_date_string
     d = Time.at(self.created_at)
     "#{d.year}-#{d.month}-#{d.day}"


### PR DESCRIPTION
 (e.g. numbers too large to be converted to Time ==> RangeError)

a buggy client was reporting timestamps that were numeric, but simply too large, leading to a RangeError from the Time class. A better or complimentary solution might be to filter these out in the graylog server on receipt; but in our case, they're already in the datastore, and it breaks the webui badly.

for example:

```
ActionView::Template::Error (1337251496950884.000000 out of Time range):
  49:         <td><%= time_to_formatted_s(Time.at(message.created_at)) %></td>`
```

(on 32 bit ubuntu 10.10)

```
irb(main):001:0> Time.at(1337251496950884.000000)
  RangeError: 1337251496950884.000000 out of Time range
```
