### PR TITLE
cleanup after #95 and #96

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'home_run', '~> 1.0.2', :platforms => :ruby
 gem 'SystemTimer', '~> 1.2.3', :require => 'system_timer', :platforms => :ruby_18
 gem 'rails_autolink', '~> 1.0.4'
 gem 'kaminari', '~> 0.12.4'
-gem 'jquery-rails', '~> 2.1'
 gem 'therubyracer', '~> 0.10.2'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,9 +59,6 @@ GEM
       activesupport
       builder
     i18n (0.6.0)
-    jquery-rails (2.1.2)
-      railties (>= 3.1.0, < 5.0)
-      thor (~> 0.14)
     json (1.5.4)
     kaminari (0.12.4)
       rails (>= 3.0.0)
@@ -171,7 +168,6 @@ DEPENDENCIES
   graylog2-declarative_authorization (~> 0.5.2)
   home_run (~> 1.0.2)
   hoptoad_notifier (~> 2.4.9)
-  jquery-rails (~> 2.1)
   json (~> 1.5.1)
   kaminari (~> 0.12.4)
   machinist_mongo (~> 1.2.0)


### PR DESCRIPTION
we do not use the jquery-rails gem any more.
