### PR TITLE
add 'elasticsearch' comment to indexer.yml

### DIFF
--- a/config/indexer.yml.example
+++ b/config/indexer.yml.example
@@ -1,3 +1,4 @@
+# Settings for the elasticsearch indexer.
 production:
   url: http://localhost:9200/
   index_prefix: graylog2


### PR DESCRIPTION
after changing the default elasticsearch cluster name and configuring the graylog2 server, i grepped for 'elasticsearch' in the config folder, but to no avail.

this commit should remedy this allowing somebody who is not familiar with the config structure to immediately find the right configuration file to change, if one changes the default elasticsearch database.
