### PR TITLE
Fix mongodb rejecting insert of second user because of unique indexes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,8 +37,8 @@ class User
   field :from_ldap, :type => Boolean, :default => false
 
   index :login,          :background => true, :unique => true
-  index :remember_token, :background => true, :unique => true
-  index :api_key,          :background => true, :unique => true
+  index :remember_token, :background => true, :unique => true, :sparse => true
+  index :api_key,          :background => true, :unique => true, :sparse => true
 
   has_and_belongs_to_many :streams, :inverse_of => :users
   has_and_belongs_to_many :favorite_streams,   :class_name => "Stream", :inverse_of => :favorited_streams


### PR DESCRIPTION
Allow inserts when values for `users.remember_token` and `users.api_key` are null. When a new user is created these values are created as `null` in the index, first user is okay but the second user is rejected because of the unique indexes.

Add `:sparse => true`.

Sparse indexes keep uniqueness when the field (`remember_token` or `api_key`) appears in the document, but when these are null on insert then mongoid will not add them to the document at all - which is allowed by a sparse index.
