### PR TITLE
Fixed LDAP user BIND to correctly user full DN

### DIFF
--- a/app/models/ldap_authentication.rb
+++ b/app/models/ldap_authentication.rb
@@ -1,6 +1,10 @@
+require "net/ldap/dn"
 class LdapAuthentication
   def initialize(login, password)
     @login    = login
+    @login_dn = Net::LDAP::DN.new( ::Configuration.ldap_username_attribute, 
+                                   login,
+                                   ::Configuration.ldap_base )
     @password = password
   end
 
@@ -28,6 +32,7 @@ class LdapAuthentication
   def session
     Net::LDAP.new(:host       => ::Configuration.ldap_host,
                   :port       => ::Configuration.ldap_port,
-                  :auth => { method: :simple, username: @login, password: @password } )
+                  :base       => ::Configuration.ldap_base,
+                  :auth => { method: :simple, username: @login_dn, password: @password } )
   end
 end


### PR DESCRIPTION
The LDAP BIND requests were coming in as so:

Dec  6 13:55:57 ldap1 slapd[24317]: conn=3401926 fd=204 ACCEPT from IP=192.168.0.123:43166 (IP=0.0.0.0:389)
Dec  6 13:55:57 ldap1 slapd[24317]: conn=3401926 op=0 do_bind: invalid dn (memotype)
Dec  6 13:55:57 ldap1 slapd[24317]: conn=3401926 op=0 RESULT tag=97 err=34 text=invalid DN
Dec  6 13:55:57 ldap1 slapd[24317]: conn=3401926 fd=204 closed (connection lost)

But if you put the full DN (i.e., uid=memotype,dc=mycompany,dc=com) then it would attempt to search for uid=uid=memotype,dc=mycompany,com:

Dec  6 13:46:43 ldap1 slapd[24317]: conn=3401177 fd=319 ACCEPT from IP=192.168.0.123:43154 (IP=0.0.0.0:389)
Dec  6 13:46:43 ldap1 slapd[24317]: conn=3401177 op=0 BIND dn="uid=memotype,ou=People,dc=mycompany,dc=com" method=128
Dec  6 13:46:43 ldap1 slapd[24317]: conn=3401177 op=0 BIND dn="uid=memotype,ou=People,dc=mycompany,dc=com" mech=SIMPLE ssf=0
Dec  6 13:46:43 ldap1 slapd[24317]: conn=3401177 op=0 RESULT tag=97 err=0 text=
Dec  6 13:46:43 ldap1 slapd[24317]: conn=3401177 op=1 SRCH base="ou=People,dc=mycompany,dc=com" scope=2 deref=0 filter="(uid=uid=memotype,ou=people,dc=mycompany,dc=com"
Dec  6 13:46:43 ldap1 slapd[24317]: conn=3401177 op=1 SRCH attr=cn
Dec  6 13:46:43 ldap1 slapd[24317]: conn=3401177 op=1 SEARCH RESULT tag=101 err=0 nentries=0 text=
Dec  6 13:46:43 ldap1 slapd[24317]: conn=3401177 fd=319 closed (connection lost)

This patch fixes this by constructing a DN from the login name and binding to that. This way you don't have to specify the full bind DN every time you log in to the web interface, and it fixes the problem with the uid attribute being duplicated.
