### PR TITLE
Allow relocation of configuration files

### DIFF
--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,6 +1,6 @@
 class Configuration
   @general_config = YAML::load File.read((ENV['GRAYLOG2_BASE'] || Rails.root.to_s) + "/config/general.yml")
-  @indexer_config =YAML::load File.read((ENV['GRAYLOG2_BASE'] || Rails.root.to_s) + "/config/indexer.yml")
+  @indexer_config = YAML::load File.read((ENV['GRAYLOG2_BASE'] || Rails.root.to_s) + "/config/indexer.yml")
   @ldap_config = YAML::load File.read((ENV['GRAYLOG2_BASE'] || Rails.root.to_s) + "/config/ldap.yml")
 
   def self.config_value(root, nesting, key, default = nil)


### PR DESCRIPTION
Allows the use of a GRAYLOG2_BASE environment variable to relocate configuration files to an alternate path. Especially helpful when deploying as a .WAR file under JRuby.
