### PR TITLE
Fix ActionView::Template::Error (invalid byte sequence in UTF-8) Exception

### DIFF
--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -55,4 +55,8 @@ module MessagesHelper
     return result
   end
 
+  def replace_invalid_chars(str)
+    str.encode('UTF-16le', :invalid => :replace, :replace => '?').encode('UTF-8')
+  end
+
 end

--- a/app/views/messages/_full_message.html.erb
+++ b/app/views/messages/_full_message.html.erb
@@ -6,7 +6,7 @@
     </span>
   </h2>
 
-  <p class="messages-show-message"><%= @message.message %></p>
+  <p class="messages-show-message"><%= replace_invalid_chars(@message.message) %></p>
 
   <div id="messages-show-terms-modal" style="display: none;">
     <h2>Terms of message <span class="highlighted"><%= @message.id %></span></h2>
@@ -44,8 +44,9 @@
     <% end %>
   <% end %>
 
-  <% unless @message.full_message.blank? %>
-    <% escaped_fullmsg = h(@message.full_message) %>
+  <% full_message = replace_invalid_chars(@message.full_message)
+     unless full_message.blank? %>
+    <% escaped_fullmsg = h(full_message) %>
     <h3>Full message:</h3>
     <p class="messages-show-message messages-full-message">
       <%= raw(auto_link(escaped_fullmsg.gsub(/\n/, '<br />'), :html => { :target => "blank" }, :link => :urls)) %>

--- a/app/views/messages/_table.html.erb
+++ b/app/views/messages/_table.html.erb
@@ -54,7 +54,7 @@ additional_columns ||= []
           <td><%= message.additional_fields[col].blank? ? "-" : message.additional_fields[col] %></td>
         <% end %>
         <td colspan="2">
-          <%= message.message[0..message_length] %>
+          <%= replace_invalid_chars(message.message[0..message_length-1]) %>
           <%=raw (message.message.length > message_length) && !defined?(dont_show_links) ? "<span class='light'>...</span>" : nil %>
         </td>
       </tr>


### PR DESCRIPTION
My nxlog instance running on Windows 7 is sending event viewer entries to Graylog2 via syslog. Certain messages contain invalid UTF-8 characters which get stored by Graylog2 and cause the web interface to throw a 500 error each time the message is viewed or appears in search results. The exception from production.log is as follows:

```
MONGODB graylog2['$cmd'].find({"count"=>"streams", "query"=>{:_id=>{"$in"=>[]}}, "fields"=>nil})
  Rendered messages/_sidebar_index.html.erb (17.6ms)
  Rendered messages/_result_graph.html.erb (0.6ms)
MONGODB graylog2['settings'].find({:user_id=>BSON::ObjectId('5116403e6f9efb65bf000002'), :setting_type=>7}).sort([[:_id, :asc]])
MONGODB graylog2['settings'].find({:user_id=>BSON::ObjectId('5116403e6f9efb65bf000002'), :setting_type=>1}).sort([[:_id, :asc]])
MONGODB graylog2['filtered_terms'].find({})
  Rendered messages/_table.html.erb (19.1ms)
  Rendered messages/universalsearch.html.erb within layouts/application (62.3ms)
Completed 500 Internal Server Error in 240ms

ActionView::Template::Error (invalid byte sequence in UTF-8):
    55:         <% end %>
    56:         <td colspan="2">
    57:           <% short_message = message.message rescue "Invalid UTF-8" %>
    58:           <%= short_message %>
    59:           <%=raw (message.message.length > message_length) && !defined?(dont_show_links) ? "<span class='light'>...</span>" : nil %>
    60:         </td>
    61:       </tr>
  app/views/messages/_table.html.erb:58:in `block in _app_views_messages__table_html_erb___2392979296799035691_43196660'
  app/views/messages/_table.html.erb:46:in `each'
  app/views/messages/_table.html.erb:46:in `_app_views_messages__table_html_erb___2392979296799035691_43196660'
  app/views/messages/universalsearch.html.erb:39:in `_app_views_messages_universalsearch_html_erb__3237003117546474902_23791820'
```

I've resolved the issue by replacing invalid characters with a question mark.
