### PR TITLE
allows plugins without stream specific configuration to be added

### DIFF
--- a/app/views/streams/outputs.html.erb
+++ b/app/views/streams/outputs.html.erb
@@ -44,11 +44,10 @@ ElasticSearch output is always enabled.</div>
 	<strong>You have no output plugins installed.</strong>
 <% else %>
 	<%= form_tag(add_output_stream_path(@stream)) do %>
+		<% outputs = @outputs.reject { |o| o.requested_stream_config.nil?} %>
+		<%= select_tag :typeclass, options_for_select(outputs.map { |o| [o.name, o.typeclass] }), :id => "stream-outputs-chooser" %>
 
-		<%= select_tag :typeclass, options_for_select(@outputs.map { |o| [o.name, o.typeclass] }), :id => "stream-outputs-chooser" %>
-
-		<% @outputs.each_with_index do |output, i| %>
-			<% next if output.requested_stream_config.blank? %>
+		<% outputs.each_with_index do |output, i| %>
 			<dl class="stream-output-fields" id="stream-output-fields-<%= output.typeclass.gsub!('.', '_') %>"
 				<% if i == 0 %>
 					style="display: block;"


### PR DESCRIPTION
Before, when an output plugin that didn't have any stream specific configuration (stream_configuration was {}) we would skip adding any fields to the form, including description. This makes `streams_controller#create_output` choke.

Now at the beginning we just filter out all outputs with a nil stream_configuration. The only outputs that ever should meet this condition are ones that were added while graylog2-server has been running. When the server restarts it will write in {} or whatever the plugin desires and all will be right with the world.
