### PR TITLE
Replace new-lines with line breaks when displaying messages

### DIFF
--- a/app/views/messages/_full_message.html.erb
+++ b/app/views/messages/_full_message.html.erb
@@ -6,7 +6,7 @@
     </span>
   </h2>
 
-  <p class="messages-show-message"><%= @message.message %></p>
+  <p class="messages-show-message"><%= h(@message.message).gsub("\n", "<br/>").html_safe %></p>
 
   <div id="messages-show-terms-modal" style="display: none;">
     <h2>Terms of message <span class="highlighted"><%= @message.id %></span></h2>


### PR DESCRIPTION
When displaying most messages, stack-traces in particular, it is useful to have the lines of the stack displayed individually instead of running together.
