### PR TITLE
Un-hard-code thousands delimiter.

### DIFF
--- a/app/views/hosts/_sidebar_index.html.erb
+++ b/app/views/hosts/_sidebar_index.html.erb
@@ -16,7 +16,7 @@
     )
 %>
 
-<h3 id="hosts-sidebar-totalcount">Total messages: <%= number_with_delimiter(@total_count, :delimiter => '.') %></h3>
+<h3 id="hosts-sidebar-totalcount">Total messages: <%= number_with_delimiter(@total_count) %></h3>
 
 <br />
 <%= awesome_link "Delete host", host_path(@host), :method => :delete, :confirm => "Really delete this host? No messages will be deleted." %>

--- a/app/views/messages/_message_table_header.erb
+++ b/app/views/messages/_message_table_header.erb
@@ -4,7 +4,7 @@
   <%= render :partial => "version_check" %>
 <% end %>
 
-Currently containing <span class="highlighted"><%= number_with_delimiter(@total_count, :delimiter => '.') %></span> messages.
+Currently containing <span class="highlighted"><%= number_with_delimiter(@total_count) %></span> messages.
 
 <% if params[:filters].blank? %>
 <%= recent_index_switcher(params[:showall]) %>

--- a/app/views/messages/_quickfilter.html.erb
+++ b/app/views/messages/_quickfilter.html.erb
@@ -63,7 +63,7 @@
 </script>
 
 <% unless @quickfilter_result_count.blank? %>
-  <br />Quickfilter hit <span class="highlighted"><%= number_with_delimiter(@quickfilter_result_count, :delimiter => '.')  %></span> messages.
+  <br />Quickfilter hit <span class="highlighted"><%= number_with_delimiter(@quickfilter_result_count)  %></span> messages.
 <% end %>
 
 </div>

--- a/app/views/messages/universalsearch.html.erb
+++ b/app/views/messages/universalsearch.html.erb
@@ -11,7 +11,7 @@
 </h1>
 
 <% unless @messages.total_result_count.blank? %>
-  Search hit <span class="highlighted"><%= number_with_delimiter(@messages.total_result_count, :delimiter => '.')  %></span> messages.
+  Search hit <span class="highlighted"><%= number_with_delimiter(@messages.total_result_count)  %></span> messages.
 <% end %>
 
 <%= render :partial => "result_graph" %>

--- a/app/views/messages/universalsearch_distribution.html.erb
+++ b/app/views/messages/universalsearch_distribution.html.erb
@@ -10,7 +10,7 @@
 </h1>
 
 <% unless @messages.total_result_count.blank? %>
-  Search hit <span class="highlighted"><%= number_with_delimiter(@messages.total_result_count, :delimiter => '.')  %></span> messages.
+  Search hit <span class="highlighted"><%= number_with_delimiter(@messages.total_result_count)  %></span> messages.
 <% end %>
 
 <%= render :partial => "result_graph" %>

--- a/app/views/streams/_sidebar_index.html.erb
+++ b/app/views/streams/_sidebar_index.html.erb
@@ -31,7 +31,7 @@
     )
 %>
 
-<h3 id="streams-sidebar-totalcount">Total messages: <%= number_with_delimiter(@total_count, :delimiter => '.') %></h3>
+<h3 id="streams-sidebar-totalcount">Total messages: <%= number_with_delimiter(@total_count) %></h3>
 
 <h3>Favorited by:</h3>
 <ul id="streams-sidebar-favorites">


### PR DESCRIPTION
The delimiter was being set to '.' when formatting some numbers. This caused the result to look strange in the en locale. I removed the optional :delimiter argument to number_with_delimiter, which causes that helper to default to the locale.

The old behaviour can be restored by setting your locale's number/format/delimiter to '.'. See https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/de.yml for example.
