### PR TITLE
Fix paths when hosted in subdirectory

### DIFF
--- a/app/assets/javascripts/files/master.js
+++ b/app/assets/javascripts/files/master.js
@@ -357,7 +357,7 @@ $(document).ready(function() {
 
     setInterval(function(){
       // Update current throughput every 5 seconds
-      $.get("/health/currentthroughput", function(json) {
+      $.get(relative_url_root + "/health/currentthroughput", function(json) {
         count = $(".health-throughput-current");
         count.html(parseInt(json.count));
         count.fadeOut(200, function() {

--- a/app/views/hosts/index.html.erb
+++ b/app/views/hosts/index.html.erb
@@ -2,7 +2,7 @@
 <h1>Hosts</h1>
 
 <div id="hosts-quickjump">
-  <%= form_tag '/hosts/quickjump/', :method => :get do %>
+  <%= form_tag quickjump_hosts_path, :method => :get do %>
     <%= label_tag "hosts-quickjump-input", "Quick jump to host:" %>
     <%= text_field_tag :host, nil, :id => "hosts-quickjump-input" %>
     <%= awesome_submit_link "Go!" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
   <%= stylesheet_link_tag "messages" %>
   <%= stylesheet_link_tag "shell" %>
 
-  <script src="/assets/application.js?body=1" type="text/javascript"></script>
+  <%= javascript_include_tag("application") %>
   
   <%= javascript_include_tag("jit") if @load_jit %>
   <% if @load_flot %>

--- a/app/views/messages/_quickfilter.html.erb
+++ b/app/views/messages/_quickfilter.html.erb
@@ -72,7 +72,7 @@
   <%= render :partial => "result_graph" %>
   <br />
 
-  <%= form_tag "/messages", :method => :get do %>
+  <%= form_tag messages_path, :method => :get do %>
 
     <% params[:filters].each do |k,v| %>
       <% next if v.blank? or k == "additional" %>

--- a/app/views/messages/universalsearch.html.erb
+++ b/app/views/messages/universalsearch.html.erb
@@ -17,7 +17,7 @@
 <%= render :partial => "result_graph" %>
 <br />
 
-<%= form_tag "/messages/universalsearch", :method => :get do %>
+<%= form_tag universalsearch_messages_path, :method => :get do %>
 	<%= hidden_field_tag "timespan", params[:timespan] %>
 	<%= hidden_field_tag "query", params[:query] %>
 

--- a/app/views/messages/universalsearch_distribution.html.erb
+++ b/app/views/messages/universalsearch_distribution.html.erb
@@ -16,7 +16,7 @@
 <%= render :partial => "result_graph" %>
 <br />
 
-<%= form_tag "/messages/universalsearch", :method => :get do %>
+<%= form_tag universalsearch_messages_path, :method => :get do %>
 	<%= hidden_field_tag "timespan", params[:timespan] %>
 	<%= hidden_field_tag "query", params[:query] %>
 
@@ -35,7 +35,7 @@
 </script>
 <br  />
 
-<%= awesome_link "Back to search results", "/messages/universalsearch?timespan=#{params[:timespan]}&query=#{params[:query]}" %>
+<%= awesome_link "Back to search results", "#{universalsearch_messages_path}?timespan=#{params[:timespan]}&query=#{params[:query]}" %>
 <br /><br />
 
 <%= render :partial => "result_distribution", :locals => { :distribution_result => @messages } %>

--- a/app/views/plugin_configuration/configure.html.erb
+++ b/app/views/plugin_configuration/configure.html.erb
@@ -4,7 +4,7 @@
 	<strong>Plugin did not request any configuration.</strong>
 	<br />
 <% else %>
-	<%= form_tag "/plugin_configuration/configure/#{params[:plugin_type]}/#{params[:typeclass]}" do %>
+	<%= form_tag "plugin_configuration/configure/#{params[:plugin_type]}/#{params[:typeclass]}" do %>
 
 		<dl class="plugin-configuration">
 			<% @requested_fields.each do |field, title| %>

--- a/app/views/systemsettings/index.html.erb
+++ b/app/views/systemsettings/index.html.erb
@@ -46,7 +46,7 @@ All currently installed alarm callback plugins are listed here. You can enable/d
 				toggle_alarmcallback_force_systemsettings_path(:typeclass => callback.typeclass),
 				SystemSetting.alarm_callback_forced?(callback.typeclass)) %>
 			<br />
-			<%= link_to "Configure", "/plugin_configuration/configure/alarm_callback/#{callback.typeclass}" %>
+			<%= link_to "Configure", "plugin_configuration/configure/alarm_callback/#{callback.typeclass}" %>
 		</div>
 	<% end %>
 <% end %>
@@ -65,7 +65,7 @@ All currently installed message output plugins are listed here. You can configur
 		<div class="lines-line">
 			<h3><%= output.name %></h3>
 			<strong>Type:</strong> <%= output.typeclass %><br />
-			<%= link_to "Configure", "/plugin_configuration/configure/message_output/#{output.typeclass}" %>
+			<%= link_to "Configure", "plugin_configuration/configure/message_output/#{output.typeclass}" %>
 		</div>
 	<% end %>
 <% end %>
@@ -79,7 +79,7 @@ All currently installed message output plugins are listed here. You can configur
 		<div class="lines-line">
 			<h3><%= input.name %></h3>
 			<strong>Type:</strong> <%= input.typeclass %><br />
-			<%= link_to "Configure", "/plugin_configuration/configure/message_input/#{input.typeclass}" %>
+			<%= link_to "Configure", "plugin_configuration/configure/message_input/#{input.typeclass}" %>
 		</div>
 	<% end %>
 <% end %>
@@ -93,7 +93,7 @@ All currently installed message output plugins are listed here. You can configur
 		<div class="lines-line">
 			<h3><%= transport.name %></h3>
 			<strong>Type:</strong> <%= transport.typeclass %><br />
-			<%= link_to "Configure", "/plugin_configuration/configure/transport/#{transport.typeclass}" %>
+			<%= link_to "Configure", "plugin_configuration/configure/transport/#{transport.typeclass}" %>
 		</div>
 	<% end %>
 <% end %>
@@ -107,7 +107,7 @@ All currently installed message output plugins are listed here. You can configur
 		<div class="lines-line">
 			<h3><%= init.name %></h3>
 			<strong>Type:</strong> <%= init.typeclass %><br />
-			<%= link_to "Configure", "/plugin_configuration/configure/initializer/#{init.typeclass}" %>
+			<%= link_to "Configure", "plugin_configuration/configure/initializer/#{init.typeclass}" %>
 		</div>
 	<% end %>
 <% end %>


### PR DESCRIPTION
I ran into problems with the paths in URLs generated by some parts of graylog2's web interface when hosting it in a subdirectory (e.g. https://example.com/graylog2/ instead of https://graylog2.example.com/). Below are all the changes I've found so far that are needed to correct the paths. Please let me know if these look good, or if you prefer I fix the paths in some other way. If you can think of any other places I need to make changes, let me know and I'll have a go at it.
