### PR TITLE
Needed for corresponding patch to graylog2-server which fixes input spawn bug

### DIFF
--- a/app/models/Input.java
+++ b/app/models/Input.java
@@ -197,7 +197,7 @@ public class Input {
         try {
             GaugeResponse response = api.get(GaugeResponse.class)
                 .node(node)
-                .path("/system/metrics/{0}.{1}", type, name)
+                .path("/system/metrics/{0}.{1}.{2}", type, id, name)
                 .expect(200, 404)
                 .execute();
 


### PR DESCRIPTION
Corresponding minimal change for the web interface which fixes the bug that prevents a second input that is tracking connection metrcis to spawn because of non-unique metric ids.
