### PR TITLE
Add delimiter selection for tokenizer-converter.

### DIFF
--- a/app/models/Extractor.java
+++ b/app/models/Extractor.java
@@ -227,6 +227,11 @@ public class Extractor {
                     config.put("split_by", form.get("converter_split_and_count_by")[0]);
                 }
                 break;
+            case TOKENIZER:
+            	if (formFieldSet(form, "delimiter")) {
+            		config.put("delimiter",  form.get("delimiter")[0]);
+            	}
+            	break;
             case CSV:
                 if (formFieldSet(form, "csv_column_header")) {
                     config.put("column_header", form.get("csv_column_header")[0]);
@@ -265,6 +270,8 @@ public class Extractor {
                     config.put("trim_leading_whitespace", Boolean.valueOf(form.get("csv_trim_leading_whitespace")[0]));
                 }
                 break;
+		default:
+			break;
         }
 
         return config;

--- a/app/views/system/inputs/extractors/converters/tokenizer.scala.html
+++ b/app/views/system/inputs/extractors/converters/tokenizer.scala.html
@@ -3,4 +3,13 @@
         <input type="checkbox" value="enabled" name="converter_tokenizer">
         Add Key=Value pairs as fields
     </label>
+    
+    <div class="xtrc-converter-subfield">
+        <label for="converter_tokenizer_delimiter">
+            Separator character:
+            @views.html.partials.support.bubble("graylog2-web-interface/tokenizer-converter")
+        </label>
+        <input name="delimiter" id="converter_tokenizer_delimiter" type="text" value="=" maxlength="1" class="input-mini" />
+        <span class="help-block">Key value delimiter will be set to this value. Defaults to '='.</span>
+    </div>
 </div>


### PR DESCRIPTION
This is the web interface work to go with the graylog2-server work to allow the delimiter to be configurable when using the tokenizer converter (Issue 304 in graylog2-server).
