### PR TITLE
Show rickshaw graph dates in configured/user timezone

### DIFF
--- a/app/lib/DateTools.java
+++ b/app/lib/DateTools.java
@@ -85,4 +85,22 @@ public class DateTools {
     public static DateTime nowInUTC() {
         return DateTime.now(DateTimeZone.UTC);
     }
+
+    public static int getUserTimeZoneOffset() {
+        DateTimeZone tz = globalTimezone;
+
+        final User currentUser = UserService.current();
+
+        if (currentUser != null && currentUser.getTimeZone() != null) {
+            tz = currentUser.getTimeZone();
+        }
+
+        int offsetMillis = tz.toTimeZone().getRawOffset() / 1000;
+
+        if (tz.toTimeZone().useDaylightTime()) {
+            offsetMillis += 3600;
+        }
+
+        return (offsetMillis / 60) * -1;
+    }
 }

--- a/app/views/partials/top.scala.html
+++ b/app/views/partials/top.scala.html
@@ -1,10 +1,12 @@
 @import lib.security.RestPermissions._
 @import views.helpers.Permissions._
 @import lib.Configuration
+@import lib.DateTools
 
 <script type="text/javascript">
 // needs to be global!
 gl2AppPathPrefix = "@Configuration.getApplicationContext";
+gl2UserTimeZoneOffset = @DateTools.getUserTimeZoneOffset;
 </script>
 
 <div id="top" class="navbar navbar-fixed-top">

--- a/app/views/search/results.scala.html
+++ b/app/views/search/results.scala.html
@@ -163,14 +163,15 @@
             new Rickshaw.Graph.Axis.Time({
                 graph: resultGraph,
                 ticksTreatment: "glow",
-                timeFixture: new Rickshaw.Fixtures.Graylog2Time() // Cares about correct TZ handling.
+                timeFixture: new Rickshaw.Fixtures.Graylog2Time(gl2UserTimeZoneOffset) // Cares about correct TZ handling.
             });
         }
 
         new Rickshaw.Graph.HoverDetail({
             graph: resultGraph,
             formatter: function(series, x, y) {
-                var date = '<span class="date">' + new Date(x * 1000 ).toString() + '</span>';
+                var dateMoment = moment(new Date(x * 1000 )).zone(gl2UserTimeZoneOffset);
+                var date = '<span class="date">' + dateMoment.format('ddd MMM DD YYYY HH:mm:ss ZZ') + '</span>';
                 var swatch = '<span class="detail_swatch"></span>';
                 var content = parseInt(y) + ' messages<br>' + date;
                 return content;

--- a/public/javascripts/Rickshaw.Fixtures.Graylog2Time.js
+++ b/public/javascripts/Rickshaw.Fixtures.Graylog2Time.js
@@ -1,6 +1,6 @@
 Rickshaw.namespace('Rickshaw.Fixtures.Graylog2Time');
 
-Rickshaw.Fixtures.Graylog2Time = function() {
+Rickshaw.Fixtures.Graylog2Time = function(tzOffset) {
 
 	var self = this;
 
@@ -67,11 +67,23 @@ Rickshaw.Fixtures.Graylog2Time = function() {
 	};
 
 	this.formatDate = function(d) {
-		return d3.time.format('%b %e')(d);
+		var dateMoment = moment(d);
+
+		if (tzOffset) {
+			dateMoment = dateMoment.zone(tzOffset);
+		}
+
+		return dateMoment.format('MMM DD');
 	};
 
 	this.formatTime = function(d) {
-		return d.toString().match(/(\d+:\d+):/)[1];
+		var dateMoment = moment(d);
+
+		if (tzOffset) {
+			dateMoment = dateMoment.zone(tzOffset);
+		}
+
+		return dateMoment.format('HH:mm');
 	};
 
 	this.ceil = function(time, unit) {

--- a/public/javascripts/analyzers/analyzers/fieldcharts.js
+++ b/public/javascripts/analyzers/analyzers/fieldcharts.js
@@ -168,7 +168,7 @@ $(document).ready(function() {
                 new Rickshaw.Graph.Axis.Time({
                     graph: graph,
                     ticksTreatment: "glow",
-                    timeFixture: new Rickshaw.Fixtures.Graylog2Time() // Cares about correct TZ handling.
+                    timeFixture: new Rickshaw.Fixtures.Graylog2Time(gl2UserTimeZoneOffset) // Cares about correct TZ handling.
                 });
 
                 new Rickshaw.Graph.HoverDetail({

--- a/public/javascripts/dashboards/widgets/field_chart.js
+++ b/public/javascripts/dashboards/widgets/field_chart.js
@@ -86,7 +86,7 @@ function updateWidget_field_chart(widget, data) {
     new Rickshaw.Graph.Axis.Time({
         graph: graph,
         ticksTreatment: "glow",
-        timeFixture: new Rickshaw.Fixtures.Graylog2Time() // Cares about correct TZ handling.
+        timeFixture: new Rickshaw.Fixtures.Graylog2Time(gl2UserTimeZoneOffset) // Cares about correct TZ handling.
     });
 
     new Rickshaw.Graph.HoverDetail({

--- a/public/javascripts/dashboards/widgets/search_result_chart.js
+++ b/public/javascripts/dashboards/widgets/search_result_chart.js
@@ -61,7 +61,7 @@ function updateWidget_search_result_chart(widget, data) {
         new Rickshaw.Graph.Axis.Time({
             graph: graph,
             ticksTreatment: "glow",
-            timeFixture: new Rickshaw.Fixtures.Graylog2Time() // Cares about correct TZ handling.
+            timeFixture: new Rickshaw.Fixtures.Graylog2Time(gl2UserTimeZoneOffset) // Cares about correct TZ handling.
         });
     }
 


### PR DESCRIPTION
The date and time annotations for the graphs are currently shown in the browser timezone.
