### PR TITLE
wrap field name with single quotas in quick values

### DIFF
--- a/app/assets/javascripts/analyzers/analyzers/quickvalues.js
+++ b/app/assets/javascripts/analyzers/analyzers/quickvalues.js
@@ -89,7 +89,7 @@ $(document).ready(function() {
             $(".terms-distribution", quickvalues).hide();
         }
 
-        var button = $(".analyze-field .show-quickvalues[data-field=" + field + "]");
+        var button = $(".analyze-field .show-quickvalues[data-field='" + field + "']");
         updatePosition(button, quickvalues, direction);
 
         switch(direction)  {


### PR DESCRIPTION
field names with dots (e.g. req.body.event.time) cannot be used in quick values and causes error:

`Uncaught Error: Syntax error, unrecognized expression: [data-field=FIELD_NAME]`

this commit fixes this issue by using single quotas around field name
