### PR TITLE
More readable display of multiline messages in search results

### DIFF
--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -196,6 +196,12 @@ h1.username {
 	word-wrap:break-word;
 }
 
+.messages-message div {
+	white-space:pre;
+	max-height: 160px;
+	overflow: hidden;
+}
+
 .messages th {
 	font-size: 13px;
 }

--- a/app/views/search/results.scala.html
+++ b/app/views/search/results.scala.html
@@ -348,7 +348,7 @@
                 class="result-td-36cd38f49b9afa08222c0dc9ebfe35eb">@r.getFields.get("source")</td>
 			<td @if(!(selectedFields.contains("message") || search.getOrder.getField.equals("message"))) { style="display: none;" }
                 class="messages-message result-td-78e731027d8fd50ed642340b7c9a63b3">
-                @renderMessageResultField("message", r.getFields, r)
+                <div>@renderMessageResultField("message", r.getFields, r)</div>
             </td>
 			
 			@for(f <- searchResult.getPageFields()) {


### PR DESCRIPTION
Multiline messages are shown a bit nicer in the search results:  Max height is limited to 160px, line breaks are respected by using pre formatting and overflow is hidden. This makes especially stack traces and similar long multiline messages a lot easier to read and navigate