### PR TITLE
Change Log Out button icon to "signout" icon

### DIFF
--- a/app/views/partials/top.scala.html
+++ b/app/views/partials/top.scala.html
@@ -43,7 +43,7 @@ gl2UserTimeZoneOffset = @DateTools.getUserTimeZoneOffset(UserService.current());
                     <strong class="total-throughput focuslimit"></strong> msg/s<span class="total-nodes"></span>.
                 </span>
 
-                <a href="@routes.SessionsController.destroy()" title="Logout" id="logout" class="btn btn-small btn-danger"><i class="icon-off"></i></a>
+                <a href="@routes.SessionsController.destroy()" title="Logout" id="logout" class="btn btn-medium btn-danger"><i class="icon-signout"></i></a>
             </div>
         </div>
  	</div>


### PR DESCRIPTION
The Log-out button looks like a Power Off button. That fact is always a little worrying whenever I go to press the button. This patch changes the Log-out button icon to icon-signout, instead of icon-off.