### PR TITLE
Added validation to stop single quotes being included in username. 

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -485,22 +485,27 @@ $(document).ready(function() {
         var domElement = createUsernameField[0];
         delayedAjaxCallOnKeyup( domElement, function() {
             var username =  createUsernameField.val();
-            $.ajax({
-                url: appPrefixed("/a/system/users/" + encodeURIComponent(username)),
-                type: "GET",
-                cache: false,
-                global: false,
-                statusCode: {
-                    204: function() {
-                        validationFailure( createUsernameField, "Username is already taken.");
-                        domElement.setCustomValidity('The entered user name is already taken.');
-                    },
-                    404: function() {
-                        createUsernameField.popover("destroy");
-                        domElement.setCustomValidity('');
-                    }
-                }
-            });
+            if (username.indexOf("'") > -1 ) {
+              validationFailure( createUsernameField, "Username can't have quotes.");
+              domElement.setCustomValidity('Username cannot have quotes.');
+            } else {
+              $.ajax({
+                  url: appPrefixed("/a/system/users/" + encodeURIComponent(username)),
+                  type: "GET",
+                  cache: false,
+                  global: false,
+                  statusCode: {
+                      204: function() {
+                          validationFailure( createUsernameField, "Username is already taken.");
+                          domElement.setCustomValidity('The entered user name is already taken.');
+                      },
+                      404: function() {
+                          createUsernameField.popover("destroy");
+                          domElement.setCustomValidity('');
+                      }
+                  }
+              });
+            }
         }, 150 );
     }
 


### PR DESCRIPTION
Without this validation, a username including a single quote can't log in, and the user cannot be deleted.

The fact that the app doesn't handle single quotes in log in makes you think of SQL injection .....

I tried logging in with some dodgy usernames & password e.g. ' or '1'='1 but couldn't break in .... haven't looked at the code behind it though .....