### PR TITLE
Masking passwords in Output configuration in web interface.

### DIFF
--- a/app/views/streams/outputs/index.scala.html
+++ b/app/views/streams/outputs/index.scala.html
@@ -64,7 +64,7 @@
 
         @if(outputs.size > 0) {
             @for(output <- outputs.toSeq.sortBy(_.getTitle.toLowerCase)) {
-                @views.html.system.outputs.partials.output_summary.render(output, stream)
+                @views.html.system.outputs.partials.output_summary.render(output, stream, availableOutputs.get(output.getType))
             }
         } else {
             <div class="alert alert-info">

--- a/app/views/system/outputs/index.scala.html
+++ b/app/views/system/outputs/index.scala.html
@@ -38,7 +38,7 @@
 
     @if(outputs.size > 0) {
         @for(output <- outputs.toSeq.sortBy(_.getTitle)) {
-            @views.html.system.outputs.partials.output_summary.render(output, null)
+            @views.html.system.outputs.partials.output_summary.render(output, null, availableOutputs.get(output.getType))
         }
     } else {
         <div class="alert alert-info">There are no outputs.</div>

--- a/app/views/system/outputs/partials/output_summary.scala.html
+++ b/app/views/system/outputs/partials/output_summary.scala.html
@@ -1,4 +1,4 @@
-@(output: org.graylog2.restclient.models.Output, stream: org.graylog2.restclient.models.Stream)
+@(output: org.graylog2.restclient.models.Output, stream: org.graylog2.restclient.models.Stream, outputType: org.graylog2.restclient.models.api.responses.AvailableOutputSummary)
 
 @import lib.security.RestPermissions._;
 @import views.helpers.Permissions._;
@@ -40,7 +40,7 @@
         @if(output.getConfiguration == null || output.getConfiguration.isEmpty) {
             <li>-- no configuration --</li>
         } else {
-            @for((k,v) <- output.getConfiguration) {
+            @for((k,v) <- output.getConfiguration(outputType.getRequestedConfiguration)) {
                 <li>@k: @v</li>
             }
         }


### PR DESCRIPTION
Using helper method of Output representation class of rest client to
display Output configurations in the web interface.

Server is now returning passwords of Output configurations unmasked, masking is done in the web interface so future editing capabilities for Outputs will work.

Needs https://github.com/Graylog2/graylog2-server/pull/1028 to be merged.
