### PR TITLE
Fixing NPE when listing alarm callback using nonexistent plugin.

### DIFF
--- a/app/views/partials/alerts/list_alarm_callbacks.scala.html
+++ b/app/views/partials/alerts/list_alarm_callbacks.scala.html
@@ -27,7 +27,11 @@
 
             <h3>
                 <i class="icon icon-ellipsis-vertical"></i>
-                @availableAlarmCallbacks.get(callback.getType).name
+                @if(availableAlarmCallbacks.get(callback.getType) != null) {
+                    @availableAlarmCallbacks.get(callback.getType).name
+                } else {
+                    -- Alarmcallback plugin (@callback.getType) not available --
+                }
             </h3>
 
             <div class="well well-small">


### PR DESCRIPTION
This prevents an NPE when listing alarm callbacks if one of the
callbacks is using a now nonexistent plugin.
It was solved this way instead of filtering out nonexistent callback
types in the server to allow viewing/deleting those callbacks.

Fixes #1152