### PR TITLE
Add system job information to overview on System page

### DIFF
--- a/app/views/system/index.scala.html
+++ b/app/views/system/index.scala.html
@@ -75,11 +75,11 @@
         provide progress information or can be stopped.
 
         @for(job <- jobs) {
-            <div class="systemjob systemjob-progress systemjob-active" id="job-@job.getId()" data-job-id="@job.getId()">
+            <div class="systemjob systemjob-progress systemjob-active" id="job-@job.getId" data-job-id="@job.getId">
                 <i class="icon icon-cog"></i>
-                Started @job.getName
+                Started <span data-toggle="tooltip" title="@job.getInfo">@job.getName</span>
                 on @partials.links.to_node(job.getNode)
-                at @DateHelper.timestampShortTZ(job.getStartedAt())
+                at @DateHelper.timestampShortTZ(job.getStartedAt)
 
                 <span class="label label-success finished">Finished!</span>
 


### PR DESCRIPTION
Display the additional information on system jobs on the System overview page (where running system jobs are listed).

Refs Graylog2/graylog2-server#920 and relies on Graylog2/graylog2-server#1054 being merged.