### PR TITLE
Initial support for websocket communication for subscribing to metrics

### DIFF
--- a/app/controllers/api/MetricsController.java
+++ b/app/controllers/api/MetricsController.java
@@ -1,0 +1,171 @@
+package controllers.api;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import controllers.AuthenticatedController;
+import models.sockjs.CreateSessionCommand;
+import models.sockjs.MetricValuesUpdate;
+import models.sockjs.SockJsCommand;
+import models.sockjs.SubscribeMetricsUpdates;
+import models.sockjs.UnsubscribeMetricsUpdates;
+import org.graylog2.restclient.lib.APIException;
+import org.graylog2.restclient.lib.ApiClient;
+import org.graylog2.restclient.lib.metrics.Metric;
+import org.graylog2.restclient.models.Node;
+import org.graylog2.restclient.models.NodeService;
+import org.graylog2.restclient.models.api.requests.MultiMetricRequest;
+import org.graylog2.restclient.models.api.responses.metrics.MetricsListResponse;
+import play.Logger;
+import play.Play;
+import play.libs.Crypto;
+import play.libs.F;
+import play.libs.Json;
+import play.mvc.Http;
+import play.sockjs.CookieCalculator;
+import play.sockjs.SockJS;
+import play.sockjs.SockJSRouter;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.graylog2.restroutes.generated.routes.MetricsResource;
+
+public class MetricsController extends AuthenticatedController {
+
+    private final NodeService nodeService;
+    private final ScheduledExecutorService executor;
+
+    private static ObjectMapper objectMapper = new ObjectMapper().enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE);
+
+    @Inject
+    public MetricsController(NodeService nodeService) {
+        executor = Executors.newSingleThreadScheduledExecutor();
+        this.nodeService = nodeService;
+    }
+
+    public static SockJSRouter metrics = new SockJSRouter() {
+
+        @Override
+        public SockJS sockjs() {
+
+            // this is the dance to get DI working
+            final MetricsController controllerInstance =
+                    Play.application()
+                            .getWrappedApplication()
+                            .global()
+                            .getControllerInstance(MetricsController.class);
+
+            return new SockJS() {
+
+                private Set<String> subscribedMetrics = Sets.newHashSet();
+
+                private String clearSessionId;
+
+                @Override
+                public void onReady(final In in, final Out out) {
+
+                    in.onMessage(new F.Callback<String>() {
+                        @Override
+                        public void invoke(String s) throws Throwable {
+                            try {
+                                final SockJsCommand command = objectMapper.readValue(s, SockJsCommand.class);
+                                if (command instanceof CreateSessionCommand) {
+
+                                    final String sessionId = ((CreateSessionCommand) command).sessionId;
+
+                                    final String userAndSessionId = Crypto.decryptAES(sessionId);
+                                    final StringTokenizer tokenizer = new StringTokenizer(userAndSessionId, "\t");
+                                    if (tokenizer.countTokens() != 2) {
+                                        Logger.warn("Invalid credentials '{}' for sockjs connection, closing socket.",
+                                                    userAndSessionId);
+                                        out.close();
+                                    }
+                                    //noinspection unused
+                                    String ignored = tokenizer.nextToken();
+                                    clearSessionId = tokenizer.nextToken();
+
+                                    Logger.warn("session is {}", clearSessionId);
+
+                                } else if (command instanceof SubscribeMetricsUpdates) {
+                                    for (String metric : ((SubscribeMetricsUpdates) command).metrics) {
+                                        Logger.warn("Subscribed to metric {}", metric);
+                                        subscribedMetrics.add(metric);
+                                    }
+                                } else if (command instanceof UnsubscribeMetricsUpdates) {
+                                    for (String metric : ((UnsubscribeMetricsUpdates) command).metrics) {
+                                        subscribedMetrics.remove(metric);
+                                    }
+                                }
+                            } catch (Exception e) {
+                                Logger.error("Unhandled exception", e);
+                            }
+                        }
+                    });
+
+                    final ScheduledFuture<?> scheduledFuture = controllerInstance.executor.scheduleAtFixedRate(
+                            new Runnable() {
+                                @Override
+                                public void run() {
+                                    // don't send anything if not authenticated or nothing is requested
+                                    if (clearSessionId == null || subscribedMetrics.isEmpty()) {
+                                        return;
+                                    }
+                                    try {
+                                        final ApiClient api = controllerInstance.api();
+
+                                        final Node node = controllerInstance.nodeService.loadMasterNode();
+
+                                        final MultiMetricRequest request = new MultiMetricRequest();
+                                        request.metrics = subscribedMetrics.toArray(new String[subscribedMetrics.size()]);
+
+                                        MetricsListResponse response = api.path(MetricsResource().multipleMetrics(), MetricsListResponse.class)
+                                                .node(node)
+                                                .body(request)
+                                                .session(clearSessionId)
+                                                .extendSession(false)
+                                                .expect(200)
+                                                .execute();
+
+                                        final MetricValuesUpdate valuesUpdate = new MetricValuesUpdate();
+                                        valuesUpdate.nodeId = node.getNodeId();
+                                        valuesUpdate.values = Lists.newArrayList();
+                                        for (Map.Entry<String, Metric> entry : response.getMetrics().entrySet()) {
+                                            valuesUpdate.values.add(new MetricValuesUpdate.NamedMetric(entry.getKey(), entry.getValue()));
+                                        }
+
+                                        out.write(Json.toJson(valuesUpdate).toString());
+                                    } catch (APIException | IOException e) {
+                                        Logger.warn("Unable to load metrics", e);
+                                    }
+                                }
+                            }, 1, 1, TimeUnit.SECONDS);
+
+                    in.onClose(new F.Callback0() {
+                        @Override
+                        public void invoke() throws Throwable {
+                            scheduledFuture.cancel(true);
+                            Logger.info("Good bye.");
+                        }
+                    });
+
+                }
+            };
+        }
+    };
+
+    public static class Graylog2Cookie implements CookieCalculator {
+        @Override
+        public Http.Cookie cookie(Http.RequestHeader request) {
+            return null;
+        }
+    }
+}

--- a/app/lib/SockJSController.java
+++ b/app/lib/SockJSController.java
@@ -1,0 +1,6 @@
+package lib;
+
+import controllers.AuthenticatedController;
+
+public abstract class SockJSController extends AuthenticatedController {
+}

--- a/app/models/sockjs/CreateSessionCommand.java
+++ b/app/models/sockjs/CreateSessionCommand.java
@@ -1,0 +1,7 @@
+package models.sockjs;
+
+public class CreateSessionCommand extends SockJsCommand {
+
+    public String sessionId;
+
+}

--- a/app/models/sockjs/MetricValuesUpdate.java
+++ b/app/models/sockjs/MetricValuesUpdate.java
@@ -1,0 +1,24 @@
+package models.sockjs;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import org.graylog2.restclient.lib.metrics.Metric;
+
+import java.util.Collection;
+
+@JsonAutoDetect
+public class MetricValuesUpdate {
+
+    public String nodeId;
+
+    public Collection<NamedMetric> values;
+
+    public static class NamedMetric {
+        public String name;
+        public Metric metric;
+
+        public NamedMetric(String name, Metric value) {
+            this.name = name;
+            metric = value;
+        }
+    }
+}

--- a/app/models/sockjs/SockJsCommand.java
+++ b/app/models/sockjs/SockJsCommand.java
@@ -1,0 +1,16 @@
+package models.sockjs;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonAutoDetect
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "command")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = CreateSessionCommand.class, name = "create_session"),
+        @JsonSubTypes.Type(value = SubscribeMetricsUpdates.class, name = "metrics_subscribe"),
+        @JsonSubTypes.Type(value = UnsubscribeMetricsUpdates.class, name = "metrics_unsubscribe")
+})
+public abstract class SockJsCommand {
+    public String command;
+}

--- a/app/models/sockjs/SockJsCommand.java
+++ b/app/models/sockjs/SockJsCommand.java
@@ -8,8 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "command")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = CreateSessionCommand.class, name = "create_session"),
-        @JsonSubTypes.Type(value = SubscribeMetricsUpdates.class, name = "metrics_subscribe"),
-        @JsonSubTypes.Type(value = UnsubscribeMetricsUpdates.class, name = "metrics_unsubscribe")
+        @JsonSubTypes.Type(value = SubscribeMetricsUpdates.class, name = "metrics_subscribe")
 })
 public abstract class SockJsCommand {
     public String command;

--- a/app/models/sockjs/SubscribeMetricsUpdates.java
+++ b/app/models/sockjs/SubscribeMetricsUpdates.java
@@ -1,5 +1,8 @@
 package models.sockjs;
 
+import java.util.List;
+
 public class SubscribeMetricsUpdates extends SockJsCommand {
-    public String metrics[];
+    public String nodeId;
+    public List<String> metrics;
 }

--- a/app/models/sockjs/SubscribeMetricsUpdates.java
+++ b/app/models/sockjs/SubscribeMetricsUpdates.java
@@ -1,0 +1,5 @@
+package models.sockjs;
+
+public class SubscribeMetricsUpdates extends SockJsCommand {
+    public String metrics[];
+}

--- a/app/models/sockjs/UnsubscribeMetricsUpdates.java
+++ b/app/models/sockjs/UnsubscribeMetricsUpdates.java
@@ -1,0 +1,6 @@
+package models.sockjs;
+
+public class UnsubscribeMetricsUpdates extends SockJsCommand {
+
+    public String metrics[];
+}

--- a/app/models/sockjs/UnsubscribeMetricsUpdates.java
+++ b/app/models/sockjs/UnsubscribeMetricsUpdates.java
@@ -1,6 +1,0 @@
-package models.sockjs;
-
-public class UnsubscribeMetricsUpdates extends SockJsCommand {
-
-    public String metrics[];
-}

--- a/app/views/partials/top.scala.html
+++ b/app/views/partials/top.scala.html
@@ -6,12 +6,14 @@
 @import org.graylog2.restclient.lib.DateTools
 @import views.helpers.Permissions
 @import lib.security.RestPermissions
+@import play.mvc.Http
 
 <script type="text/javascript">
 // needs to be global!
 gl2AppPathPrefix = "@Configuration.getApplicationContext";
 gl2UserTimeZone = "@DateTools.getUserTimeZone(UserService.current())";
 gl2UserTimeZoneOffset = @DateTools.getUserTimeZoneOffset(UserService.current());
+gl2UserSessionId = "@Http.Context.current().session().get("sessionid")";
 </script>
 
 <div id="top">

--- a/conf/routes
+++ b/conf/routes
@@ -181,6 +181,9 @@ GET         /a/messagecounts/total                                              
 # API: Message analyzing
 GET         /a/analyze/:index/:id/:field                                             @controllers.MessagesController.analyze(index: String, id: String, field: String)
 
+# Metrics via SockJS, set up new router
+->         /a/metrics                                                                controllers.api.MetricsController.metrics
+
 # API: System
 GET         /a/system/fields                                                         @controllers.api.SystemApiController.fields()
 GET         /a/system/jobs                                                           @controllers.api.SystemApiController.jobs()

--- a/javascript/declarations/node/node.d.ts
+++ b/javascript/declarations/node/node.d.ts
@@ -1,0 +1,1409 @@
+// Type definitions for Node.js v0.12.0
+// Project: http://nodejs.org/
+// Definitions by: Microsoft TypeScript <http://typescriptlang.org>, DefinitelyTyped <https://github.com/borisyankov/DefinitelyTyped>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/************************************************
+ *                                               *
+ *               Node.js v0.12.0 API             *
+ *                                               *
+ ************************************************/
+
+/************************************************
+ *                                               *
+ *                   GLOBAL                      *
+ *                                               *
+ ************************************************/
+declare var process: NodeJS.Process;
+declare var global: any;
+
+declare var __filename: string;
+declare var __dirname: string;
+
+declare function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+declare function clearTimeout(timeoutId: NodeJS.Timer): void;
+declare function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+declare function clearInterval(intervalId: NodeJS.Timer): void;
+declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): any;
+declare function clearImmediate(immediateId: any): void;
+
+declare var require: {
+    (id: string): any;
+    resolve(id:string): string;
+    cache: any;
+    extensions: any;
+    main: any;
+};
+
+declare var module: {
+    exports: any;
+    require(id: string): any;
+    id: string;
+    filename: string;
+    loaded: boolean;
+    parent: any;
+    children: any[];
+};
+
+// Same as module.exports
+declare var exports: any;
+declare var SlowBuffer: {
+    new (str: string, encoding?: string): Buffer;
+    new (size: number): Buffer;
+    new (size: Uint8Array): Buffer;
+    new (array: any[]): Buffer;
+    prototype: Buffer;
+    isBuffer(obj: any): boolean;
+    byteLength(string: string, encoding?: string): number;
+    concat(list: Buffer[], totalLength?: number): Buffer;
+};
+
+
+// Buffer class
+interface Buffer extends NodeBuffer {}
+declare var Buffer: {
+    new (str: string, encoding?: string): Buffer;
+    new (size: number): Buffer;
+    new (size: Uint8Array): Buffer;
+    new (array: any[]): Buffer;
+    prototype: Buffer;
+    isBuffer(obj: any): boolean;
+    byteLength(string: string, encoding?: string): number;
+    concat(list: Buffer[], totalLength?: number): Buffer;
+};
+
+/************************************************
+ *                                               *
+ *               GLOBAL INTERFACES               *
+ *                                               *
+ ************************************************/
+declare module NodeJS {
+    export interface ErrnoException extends Error {
+        errno?: number;
+        code?: string;
+        path?: string;
+        syscall?: string;
+    }
+
+    export interface EventEmitter {
+        addListener(event: string, listener: Function): EventEmitter;
+        on(event: string, listener: Function): EventEmitter;
+        once(event: string, listener: Function): EventEmitter;
+        removeListener(event: string, listener: Function): EventEmitter;
+        removeAllListeners(event?: string): EventEmitter;
+        setMaxListeners(n: number): void;
+        listeners(event: string): Function[];
+        emit(event: string, ...args: any[]): boolean;
+    }
+
+    export interface ReadableStream extends EventEmitter {
+        readable: boolean;
+        read(size?: number): string|Buffer;
+        setEncoding(encoding: string): void;
+        pause(): void;
+        resume(): void;
+        pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
+        unpipe<T extends WritableStream>(destination?: T): void;
+        unshift(chunk: string): void;
+        unshift(chunk: Buffer): void;
+        wrap(oldStream: ReadableStream): ReadableStream;
+    }
+
+    export interface WritableStream extends EventEmitter {
+        writable: boolean;
+        write(buffer: Buffer, cb?: Function): boolean;
+        write(str: string, cb?: Function): boolean;
+        write(str: string, encoding?: string, cb?: Function): boolean;
+        end(): void;
+        end(buffer: Buffer, cb?: Function): void;
+        end(str: string, cb?: Function): void;
+        end(str: string, encoding?: string, cb?: Function): void;
+    }
+
+    export interface ReadWriteStream extends ReadableStream, WritableStream {}
+
+    export interface Process extends EventEmitter {
+        stdout: WritableStream;
+        stderr: WritableStream;
+        stdin: ReadableStream;
+        argv: string[];
+        execPath: string;
+        abort(): void;
+        chdir(directory: string): void;
+        cwd(): string;
+        env: any;
+        exit(code?: number): void;
+        getgid(): number;
+        setgid(id: number): void;
+        setgid(id: string): void;
+        getuid(): number;
+        setuid(id: number): void;
+        setuid(id: string): void;
+        version: string;
+        versions: {
+            http_parser: string;
+            node: string;
+            v8: string;
+            ares: string;
+            uv: string;
+            zlib: string;
+            openssl: string;
+        };
+        config: {
+            target_defaults: {
+                cflags: any[];
+                default_configuration: string;
+                defines: string[];
+                include_dirs: string[];
+                libraries: string[];
+            };
+            variables: {
+                clang: number;
+                host_arch: string;
+                node_install_npm: boolean;
+                node_install_waf: boolean;
+                node_prefix: string;
+                node_shared_openssl: boolean;
+                node_shared_v8: boolean;
+                node_shared_zlib: boolean;
+                node_use_dtrace: boolean;
+                node_use_etw: boolean;
+                node_use_openssl: boolean;
+                target_arch: string;
+                v8_no_strict_aliasing: number;
+                v8_use_snapshot: boolean;
+                visibility: string;
+            };
+        };
+        kill(pid: number, signal?: string): void;
+        pid: number;
+        title: string;
+        arch: string;
+        platform: string;
+        memoryUsage(): { rss: number; heapTotal: number; heapUsed: number; };
+        nextTick(callback: Function): void;
+        umask(mask?: number): number;
+        uptime(): number;
+        hrtime(time?:number[]): number[];
+
+        // Worker
+        send?(message: any, sendHandle?: any): void;
+    }
+
+    export interface Timer {
+        ref() : void;
+        unref() : void;
+    }
+}
+
+/**
+ * @deprecated
+ */
+interface NodeBuffer {
+    [index: number]: number;
+    write(string: string, offset?: number, length?: number, encoding?: string): number;
+    toString(encoding?: string, start?: number, end?: number): string;
+    toJSON(): any;
+    length: number;
+    copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
+    slice(start?: number, end?: number): Buffer;
+    readUInt8(offset: number, noAsset?: boolean): number;
+    readUInt16LE(offset: number, noAssert?: boolean): number;
+    readUInt16BE(offset: number, noAssert?: boolean): number;
+    readUInt32LE(offset: number, noAssert?: boolean): number;
+    readUInt32BE(offset: number, noAssert?: boolean): number;
+    readInt8(offset: number, noAssert?: boolean): number;
+    readInt16LE(offset: number, noAssert?: boolean): number;
+    readInt16BE(offset: number, noAssert?: boolean): number;
+    readInt32LE(offset: number, noAssert?: boolean): number;
+    readInt32BE(offset: number, noAssert?: boolean): number;
+    readFloatLE(offset: number, noAssert?: boolean): number;
+    readFloatBE(offset: number, noAssert?: boolean): number;
+    readDoubleLE(offset: number, noAssert?: boolean): number;
+    readDoubleBE(offset: number, noAssert?: boolean): number;
+    writeUInt8(value: number, offset: number, noAssert?: boolean): void;
+    writeUInt16LE(value: number, offset: number, noAssert?: boolean): void;
+    writeUInt16BE(value: number, offset: number, noAssert?: boolean): void;
+    writeUInt32LE(value: number, offset: number, noAssert?: boolean): void;
+    writeUInt32BE(value: number, offset: number, noAssert?: boolean): void;
+    writeInt8(value: number, offset: number, noAssert?: boolean): void;
+    writeInt16LE(value: number, offset: number, noAssert?: boolean): void;
+    writeInt16BE(value: number, offset: number, noAssert?: boolean): void;
+    writeInt32LE(value: number, offset: number, noAssert?: boolean): void;
+    writeInt32BE(value: number, offset: number, noAssert?: boolean): void;
+    writeFloatLE(value: number, offset: number, noAssert?: boolean): void;
+    writeFloatBE(value: number, offset: number, noAssert?: boolean): void;
+    writeDoubleLE(value: number, offset: number, noAssert?: boolean): void;
+    writeDoubleBE(value: number, offset: number, noAssert?: boolean): void;
+    fill(value: any, offset?: number, end?: number): void;
+}
+
+/************************************************
+ *                                               *
+ *                   MODULES                     *
+ *                                               *
+ ************************************************/
+declare module "buffer" {
+    export var INSPECT_MAX_BYTES: number;
+}
+
+declare module "querystring" {
+    export function stringify(obj: any, sep?: string, eq?: string): string;
+    export function parse(str: string, sep?: string, eq?: string, options?: { maxKeys?: number; }): any;
+    export function escape(str: string): string;
+    export function unescape(str: string): string;
+}
+
+declare module "events" {
+    export class EventEmitter implements NodeJS.EventEmitter {
+        static listenerCount(emitter: EventEmitter, event: string): number;
+
+        addListener(event: string, listener: Function): EventEmitter;
+        on(event: string, listener: Function): EventEmitter;
+        once(event: string, listener: Function): EventEmitter;
+        removeListener(event: string, listener: Function): EventEmitter;
+        removeAllListeners(event?: string): EventEmitter;
+        setMaxListeners(n: number): void;
+        listeners(event: string): Function[];
+        emit(event: string, ...args: any[]): boolean;
+    }
+}
+
+declare module "http" {
+    import events = require("events");
+    import net = require("net");
+    import stream = require("stream");
+
+    export interface Server extends events.EventEmitter {
+        listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
+        listen(path: string, callback?: Function): Server;
+        listen(handle: any, listeningListener?: Function): Server;
+        close(cb?: any): Server;
+        address(): { port: number; family: string; address: string; };
+        maxHeadersCount: number;
+    }
+    export interface ServerRequest extends events.EventEmitter, stream.Readable {
+        method: string;
+        url: string;
+        headers: any;
+        trailers: string;
+        httpVersion: string;
+        setEncoding(encoding?: string): void;
+        pause(): void;
+        resume(): void;
+        connection: net.Socket;
+    }
+    export interface ServerResponse extends events.EventEmitter, stream.Writable {
+        // Extended base methods
+        write(buffer: Buffer): boolean;
+        write(buffer: Buffer, cb?: Function): boolean;
+        write(str: string, cb?: Function): boolean;
+        write(str: string, encoding?: string, cb?: Function): boolean;
+        write(str: string, encoding?: string, fd?: string): boolean;
+
+        writeContinue(): void;
+        writeHead(statusCode: number, reasonPhrase?: string, headers?: any): void;
+        writeHead(statusCode: number, headers?: any): void;
+        statusCode: number;
+        setHeader(name: string, value: string): void;
+        sendDate: boolean;
+        getHeader(name: string): string;
+        removeHeader(name: string): void;
+        write(chunk: any, encoding?: string): any;
+        addTrailers(headers: any): void;
+
+        // Extended base methods
+        end(): void;
+        end(buffer: Buffer, cb?: Function): void;
+        end(str: string, cb?: Function): void;
+        end(str: string, encoding?: string, cb?: Function): void;
+        end(data?: any, encoding?: string): void;
+    }
+    export interface ClientRequest extends events.EventEmitter, stream.Writable {
+        // Extended base methods
+        write(buffer: Buffer): boolean;
+        write(buffer: Buffer, cb?: Function): boolean;
+        write(str: string, cb?: Function): boolean;
+        write(str: string, encoding?: string, cb?: Function): boolean;
+        write(str: string, encoding?: string, fd?: string): boolean;
+
+        write(chunk: any, encoding?: string): void;
+        abort(): void;
+        setTimeout(timeout: number, callback?: Function): void;
+        setNoDelay(noDelay?: boolean): void;
+        setSocketKeepAlive(enable?: boolean, initialDelay?: number): void;
+
+        // Extended base methods
+        end(): void;
+        end(buffer: Buffer, cb?: Function): void;
+        end(str: string, cb?: Function): void;
+        end(str: string, encoding?: string, cb?: Function): void;
+        end(data?: any, encoding?: string): void;
+    }
+    export interface ClientResponse extends events.EventEmitter, stream.Readable {
+        statusCode: number;
+        httpVersion: string;
+        headers: any;
+        trailers: any;
+        setEncoding(encoding?: string): void;
+        pause(): void;
+        resume(): void;
+    }
+
+    export interface AgentOptions {
+        /**
+         * Keep sockets around in a pool to be used by other requests in the future. Default = false
+         */
+        keepAlive?: boolean;
+        /**
+         * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
+         * Only relevant if keepAlive is set to true.
+         */
+        keepAliveMsecs?: number;
+        /**
+         * Maximum number of sockets to allow per host. Default for Node 0.10 is 5, default for Node 0.12 is Infinity
+         */
+        maxSockets?: number;
+        /**
+         * Maximum number of sockets to leave open in a free state. Only relevant if keepAlive is set to true. Default = 256.
+         */
+        maxFreeSockets?: number;
+    }
+
+    export class Agent {
+        maxSockets: number;
+        sockets: any;
+        requests: any;
+
+        constructor(opts?: AgentOptions);
+
+        /**
+         * Destroy any sockets that are currently in use by the agent.
+         * It is usually not necessary to do this. However, if you are using an agent with KeepAlive enabled,
+         * then it is best to explicitly shut down the agent when you know that it will no longer be used. Otherwise,
+         * sockets may hang open for quite a long time before the server terminates them.
+         */
+        destroy(): void;
+    }
+
+    export var STATUS_CODES: {
+        [errorCode: number]: string;
+        [errorCode: string]: string;
+    };
+    export function createServer(requestListener?: (request: ServerRequest, response: ServerResponse) =>void ): Server;
+    export function createClient(port?: number, host?: string): any;
+    export function request(options: any, callback?: Function): ClientRequest;
+    export function get(options: any, callback?: Function): ClientRequest;
+    export var globalAgent: Agent;
+}
+
+declare module "cluster" {
+    import child  = require("child_process");
+    import events = require("events");
+
+    export interface ClusterSettings {
+        exec?: string;
+        args?: string[];
+        silent?: boolean;
+    }
+
+    export class Worker extends events.EventEmitter {
+        id: string;
+        process: child.ChildProcess;
+        suicide: boolean;
+        send(message: any, sendHandle?: any): void;
+        kill(signal?: string): void;
+        destroy(signal?: string): void;
+        disconnect(): void;
+    }
+
+    export var settings: ClusterSettings;
+    export var isMaster: boolean;
+    export var isWorker: boolean;
+    export function setupMaster(settings?: ClusterSettings): void;
+    export function fork(env?: any): Worker;
+    export function disconnect(callback?: Function): void;
+    export var worker: Worker;
+    export var workers: Worker[];
+
+    // Event emitter
+    export function addListener(event: string, listener: Function): void;
+    export function on(event: string, listener: Function): any;
+    export function once(event: string, listener: Function): void;
+    export function removeListener(event: string, listener: Function): void;
+    export function removeAllListeners(event?: string): void;
+    export function setMaxListeners(n: number): void;
+    export function listeners(event: string): Function[];
+    export function emit(event: string, ...args: any[]): boolean;
+}
+
+declare module "zlib" {
+    import stream = require("stream");
+    export interface ZlibOptions { chunkSize?: number; windowBits?: number; level?: number; memLevel?: number; strategy?: number; dictionary?: any; }
+
+    export interface Gzip extends stream.Transform { }
+    export interface Gunzip extends stream.Transform { }
+    export interface Deflate extends stream.Transform { }
+    export interface Inflate extends stream.Transform { }
+    export interface DeflateRaw extends stream.Transform { }
+    export interface InflateRaw extends stream.Transform { }
+    export interface Unzip extends stream.Transform { }
+
+    export function createGzip(options?: ZlibOptions): Gzip;
+    export function createGunzip(options?: ZlibOptions): Gunzip;
+    export function createDeflate(options?: ZlibOptions): Deflate;
+    export function createInflate(options?: ZlibOptions): Inflate;
+    export function createDeflateRaw(options?: ZlibOptions): DeflateRaw;
+    export function createInflateRaw(options?: ZlibOptions): InflateRaw;
+    export function createUnzip(options?: ZlibOptions): Unzip;
+
+    export function deflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function gzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function gunzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function inflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+    export function unzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
+
+    // Constants
+    export var Z_NO_FLUSH: number;
+    export var Z_PARTIAL_FLUSH: number;
+    export var Z_SYNC_FLUSH: number;
+    export var Z_FULL_FLUSH: number;
+    export var Z_FINISH: number;
+    export var Z_BLOCK: number;
+    export var Z_TREES: number;
+    export var Z_OK: number;
+    export var Z_STREAM_END: number;
+    export var Z_NEED_DICT: number;
+    export var Z_ERRNO: number;
+    export var Z_STREAM_ERROR: number;
+    export var Z_DATA_ERROR: number;
+    export var Z_MEM_ERROR: number;
+    export var Z_BUF_ERROR: number;
+    export var Z_VERSION_ERROR: number;
+    export var Z_NO_COMPRESSION: number;
+    export var Z_BEST_SPEED: number;
+    export var Z_BEST_COMPRESSION: number;
+    export var Z_DEFAULT_COMPRESSION: number;
+    export var Z_FILTERED: number;
+    export var Z_HUFFMAN_ONLY: number;
+    export var Z_RLE: number;
+    export var Z_FIXED: number;
+    export var Z_DEFAULT_STRATEGY: number;
+    export var Z_BINARY: number;
+    export var Z_TEXT: number;
+    export var Z_ASCII: number;
+    export var Z_UNKNOWN: number;
+    export var Z_DEFLATED: number;
+    export var Z_NULL: number;
+}
+
+declare module "os" {
+    export function tmpdir(): string;
+    export function hostname(): string;
+    export function type(): string;
+    export function platform(): string;
+    export function arch(): string;
+    export function release(): string;
+    export function uptime(): number;
+    export function loadavg(): number[];
+    export function totalmem(): number;
+    export function freemem(): number;
+    export function cpus(): { model: string; speed: number; times: { user: number; nice: number; sys: number; idle: number; irq: number; }; }[];
+    export function networkInterfaces(): any;
+    export var EOL: string;
+}
+
+declare module "https" {
+    import tls = require("tls");
+    import events = require("events");
+    import http = require("http");
+
+    export interface ServerOptions {
+        pfx?: any;
+        key?: any;
+        passphrase?: string;
+        cert?: any;
+        ca?: any;
+        crl?: any;
+        ciphers?: string;
+        honorCipherOrder?: boolean;
+        requestCert?: boolean;
+        rejectUnauthorized?: boolean;
+        NPNProtocols?: any;
+        SNICallback?: (servername: string) => any;
+    }
+
+    export interface RequestOptions {
+        host?: string;
+        hostname?: string;
+        port?: number;
+        path?: string;
+        method?: string;
+        headers?: any;
+        auth?: string;
+        agent?: any;
+        pfx?: any;
+        key?: any;
+        passphrase?: string;
+        cert?: any;
+        ca?: any;
+        ciphers?: string;
+        rejectUnauthorized?: boolean;
+    }
+
+    export interface Agent {
+        maxSockets: number;
+        sockets: any;
+        requests: any;
+    }
+    export var Agent: {
+        new (options?: RequestOptions): Agent;
+    };
+    export interface Server extends tls.Server { }
+    export function createServer(options: ServerOptions, requestListener?: Function): Server;
+    export function request(options: RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
+    export function get(options: RequestOptions, callback?: (res: http.ClientResponse) =>void ): http.ClientRequest;
+    export var globalAgent: Agent;
+}
+
+declare module "punycode" {
+    export function decode(string: string): string;
+    export function encode(string: string): string;
+    export function toUnicode(domain: string): string;
+    export function toASCII(domain: string): string;
+    export var ucs2: ucs2;
+    interface ucs2 {
+        decode(string: string): string;
+        encode(codePoints: number[]): string;
+    }
+    export var version: any;
+}
+
+declare module "repl" {
+    import stream = require("stream");
+    import events = require("events");
+
+    export interface ReplOptions {
+        prompt?: string;
+        input?: NodeJS.ReadableStream;
+        output?: NodeJS.WritableStream;
+        terminal?: boolean;
+        eval?: Function;
+        useColors?: boolean;
+        useGlobal?: boolean;
+        ignoreUndefined?: boolean;
+        writer?: Function;
+    }
+    export function start(options: ReplOptions): events.EventEmitter;
+}
+
+declare module "readline" {
+    import events = require("events");
+    import stream = require("stream");
+
+    export interface ReadLine extends events.EventEmitter {
+        setPrompt(prompt: string, length: number): void;
+        prompt(preserveCursor?: boolean): void;
+        question(query: string, callback: Function): void;
+        pause(): void;
+        resume(): void;
+        close(): void;
+        write(data: any, key?: any): void;
+    }
+    export interface ReadLineOptions {
+        input: NodeJS.ReadableStream;
+        output: NodeJS.WritableStream;
+        completer?: Function;
+        terminal?: boolean;
+    }
+    export function createInterface(options: ReadLineOptions): ReadLine;
+}
+
+declare module "vm" {
+    export interface Context { }
+    export interface Script {
+        runInThisContext(): void;
+        runInNewContext(sandbox?: Context): void;
+    }
+    export function runInThisContext(code: string, filename?: string): void;
+    export function runInNewContext(code: string, sandbox?: Context, filename?: string): void;
+    export function runInContext(code: string, context: Context, filename?: string): void;
+    export function createContext(initSandbox?: Context): Context;
+    export function createScript(code: string, filename?: string): Script;
+}
+
+declare module "child_process" {
+    import events = require("events");
+    import stream = require("stream");
+
+    export interface ChildProcess extends events.EventEmitter {
+        stdin:  stream.Writable;
+        stdout: stream.Readable;
+        stderr: stream.Readable;
+        pid: number;
+        kill(signal?: string): void;
+        send(message: any, sendHandle?: any): void;
+        disconnect(): void;
+    }
+
+    export function spawn(command: string, args?: string[], options?: {
+        cwd?: string;
+        stdio?: any;
+        custom?: any;
+        env?: any;
+        detached?: boolean;
+    }): ChildProcess;
+    export function exec(command: string, options: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding?: string;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+    }, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function exec(command: string, callback: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function execFile(file: string,
+                             callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function execFile(file: string, args?: string[],
+                             callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function execFile(file: string, args?: string[], options?: {
+        cwd?: string;
+        stdio?: any;
+        customFds?: any;
+        env?: any;
+        encoding?: string;
+        timeout?: number;
+        maxBuffer?: string;
+        killSignal?: string;
+    }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
+    export function fork(modulePath: string, args?: string[], options?: {
+        cwd?: string;
+        env?: any;
+        encoding?: string;
+    }): ChildProcess;
+    export function execSync(command: string, options?: {
+        cwd?: string;
+        input?: string|Buffer;
+        stdio?: any;
+        env?: any;
+        uid?: number;
+        gid?: number;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+        encoding?: string;
+    }): ChildProcess;
+    export function execFileSync(command: string, args?: string[], options?: {
+        cwd?: string;
+        input?: string|Buffer;
+        stdio?: any;
+        env?: any;
+        uid?: number;
+        gid?: number;
+        timeout?: number;
+        maxBuffer?: number;
+        killSignal?: string;
+        encoding?: string;
+    }): ChildProcess;
+}
+
+declare module "url" {
+    export interface Url {
+        href: string;
+        protocol: string;
+        auth: string;
+        hostname: string;
+        port: string;
+        host: string;
+        pathname: string;
+        search: string;
+        query: any; // string | Object
+        slashes: boolean;
+        hash?: string;
+        path?: string;
+    }
+
+    export interface UrlOptions {
+        protocol?: string;
+        auth?: string;
+        hostname?: string;
+        port?: string;
+        host?: string;
+        pathname?: string;
+        search?: string;
+        query?: any;
+        hash?: string;
+        path?: string;
+    }
+
+    export function parse(urlStr: string, parseQueryString?: boolean , slashesDenoteHost?: boolean ): Url;
+    export function format(url: UrlOptions): string;
+    export function resolve(from: string, to: string): string;
+}
+
+declare module "dns" {
+    export function lookup(domain: string, family: number, callback: (err: Error, address: string, family: number) =>void ): string;
+    export function lookup(domain: string, callback: (err: Error, address: string, family: number) =>void ): string;
+    export function resolve(domain: string, rrtype: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolve(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolve4(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolve6(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolveMx(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolveTxt(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolveSrv(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolveNs(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function resolveCname(domain: string, callback: (err: Error, addresses: string[]) =>void ): string[];
+    export function reverse(ip: string, callback: (err: Error, domains: string[]) =>void ): string[];
+}
+
+declare module "net" {
+    import stream = require("stream");
+
+    export interface Socket extends stream.Duplex {
+        // Extended base methods
+        write(buffer: Buffer): boolean;
+        write(buffer: Buffer, cb?: Function): boolean;
+        write(str: string, cb?: Function): boolean;
+        write(str: string, encoding?: string, cb?: Function): boolean;
+        write(str: string, encoding?: string, fd?: string): boolean;
+
+        connect(port: number, host?: string, connectionListener?: Function): void;
+        connect(path: string, connectionListener?: Function): void;
+        bufferSize: number;
+        setEncoding(encoding?: string): void;
+        write(data: any, encoding?: string, callback?: Function): void;
+        destroy(): void;
+        pause(): void;
+        resume(): void;
+        setTimeout(timeout: number, callback?: Function): void;
+        setNoDelay(noDelay?: boolean): void;
+        setKeepAlive(enable?: boolean, initialDelay?: number): void;
+        address(): { port: number; family: string; address: string; };
+        unref(): void;
+        ref(): void;
+
+        remoteAddress: string;
+        remoteFamily: string;
+        remotePort: number;
+        localAddress: string;
+        localPort: number;
+        bytesRead: number;
+        bytesWritten: number;
+
+        // Extended base methods
+        end(): void;
+        end(buffer: Buffer, cb?: Function): void;
+        end(str: string, cb?: Function): void;
+        end(str: string, encoding?: string, cb?: Function): void;
+        end(data?: any, encoding?: string): void;
+    }
+
+    export var Socket: {
+        new (options?: { fd?: string; type?: string; allowHalfOpen?: boolean; }): Socket;
+    };
+
+    export interface Server extends Socket {
+        listen(port: number, host?: string, backlog?: number, listeningListener?: Function): Server;
+        listen(path: string, listeningListener?: Function): Server;
+        listen(handle: any, listeningListener?: Function): Server;
+        close(callback?: Function): Server;
+        address(): { port: number; family: string; address: string; };
+        maxConnections: number;
+        connections: number;
+    }
+    export function createServer(connectionListener?: (socket: Socket) =>void ): Server;
+    export function createServer(options?: { allowHalfOpen?: boolean; }, connectionListener?: (socket: Socket) =>void ): Server;
+    export function connect(options: { allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
+    export function connect(port: number, host?: string, connectionListener?: Function): Socket;
+    export function connect(path: string, connectionListener?: Function): Socket;
+    export function createConnection(options: { allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
+    export function createConnection(port: number, host?: string, connectionListener?: Function): Socket;
+    export function createConnection(path: string, connectionListener?: Function): Socket;
+    export function isIP(input: string): number;
+    export function isIPv4(input: string): boolean;
+    export function isIPv6(input: string): boolean;
+}
+
+declare module "dgram" {
+    import events = require("events");
+
+    interface RemoteInfo {
+        address: string;
+        port: number;
+        size: number;
+    }
+
+    interface AddressInfo {
+        address: string;
+        family: string;
+        port: number;
+    }
+
+    export function createSocket(type: string, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
+
+    interface Socket extends events.EventEmitter {
+        send(buf: Buffer, offset: number, length: number, port: number, address: string, callback?: (error: Error, bytes: number) => void): void;
+        bind(port: number, address?: string, callback?: () => void): void;
+        close(): void;
+        address(): AddressInfo;
+        setBroadcast(flag: boolean): void;
+        setMulticastTTL(ttl: number): void;
+        setMulticastLoopback(flag: boolean): void;
+        addMembership(multicastAddress: string, multicastInterface?: string): void;
+        dropMembership(multicastAddress: string, multicastInterface?: string): void;
+    }
+}
+
+declare module "fs" {
+    import stream = require("stream");
+    import events = require("events");
+
+    interface Stats {
+        isFile(): boolean;
+        isDirectory(): boolean;
+        isBlockDevice(): boolean;
+        isCharacterDevice(): boolean;
+        isSymbolicLink(): boolean;
+        isFIFO(): boolean;
+        isSocket(): boolean;
+        dev: number;
+        ino: number;
+        mode: number;
+        nlink: number;
+        uid: number;
+        gid: number;
+        rdev: number;
+        size: number;
+        blksize: number;
+        blocks: number;
+        atime: Date;
+        mtime: Date;
+        ctime: Date;
+    }
+
+    interface FSWatcher extends events.EventEmitter {
+        close(): void;
+    }
+
+    export interface ReadStream extends stream.Readable {
+        close(): void;
+    }
+    export interface WriteStream extends stream.Writable {
+        close(): void;
+    }
+
+    export function rename(oldPath: string, newPath: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function renameSync(oldPath: string, newPath: string): void;
+    export function truncate(path: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function truncate(path: string, len: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function truncateSync(path: string, len?: number): void;
+    export function ftruncate(fd: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function ftruncate(fd: number, len: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function ftruncateSync(fd: number, len?: number): void;
+    export function chown(path: string, uid: number, gid: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function chownSync(path: string, uid: number, gid: number): void;
+    export function fchown(fd: number, uid: number, gid: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function fchownSync(fd: number, uid: number, gid: number): void;
+    export function lchown(path: string, uid: number, gid: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function lchownSync(path: string, uid: number, gid: number): void;
+    export function chmod(path: string, mode: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function chmod(path: string, mode: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function chmodSync(path: string, mode: number): void;
+    export function chmodSync(path: string, mode: string): void;
+    export function fchmod(fd: number, mode: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function fchmod(fd: number, mode: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function fchmodSync(fd: number, mode: number): void;
+    export function fchmodSync(fd: number, mode: string): void;
+    export function lchmod(path: string, mode: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function lchmod(path: string, mode: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function lchmodSync(path: string, mode: number): void;
+    export function lchmodSync(path: string, mode: string): void;
+    export function stat(path: string, callback?: (err: NodeJS.ErrnoException, stats: Stats) => any): void;
+    export function lstat(path: string, callback?: (err: NodeJS.ErrnoException, stats: Stats) => any): void;
+    export function fstat(fd: number, callback?: (err: NodeJS.ErrnoException, stats: Stats) => any): void;
+    export function statSync(path: string): Stats;
+    export function lstatSync(path: string): Stats;
+    export function fstatSync(fd: number): Stats;
+    export function link(srcpath: string, dstpath: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function linkSync(srcpath: string, dstpath: string): void;
+    export function symlink(srcpath: string, dstpath: string, type?: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function symlinkSync(srcpath: string, dstpath: string, type?: string): void;
+    export function readlink(path: string, callback?: (err: NodeJS.ErrnoException, linkString: string) => any): void;
+    export function readlinkSync(path: string): string;
+    export function realpath(path: string, callback?: (err: NodeJS.ErrnoException, resolvedPath: string) => any): void;
+    export function realpath(path: string, cache: {[path: string]: string}, callback: (err: NodeJS.ErrnoException, resolvedPath: string) =>any): void;
+    export function realpathSync(path: string, cache?: {[path: string]: string}): string;
+    export function unlink(path: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function unlinkSync(path: string): void;
+    export function rmdir(path: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function rmdirSync(path: string): void;
+    export function mkdir(path: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function mkdir(path: string, mode: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function mkdir(path: string, mode: string, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function mkdirSync(path: string, mode?: number): void;
+    export function mkdirSync(path: string, mode?: string): void;
+    export function readdir(path: string, callback?: (err: NodeJS.ErrnoException, files: string[]) => void): void;
+    export function readdirSync(path: string): string[];
+    export function close(fd: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function closeSync(fd: number): void;
+    export function open(path: string, flags: string, callback?: (err: NodeJS.ErrnoException, fd: number) => any): void;
+    export function open(path: string, flags: string, mode: number, callback?: (err: NodeJS.ErrnoException, fd: number) => any): void;
+    export function open(path: string, flags: string, mode: string, callback?: (err: NodeJS.ErrnoException, fd: number) => any): void;
+    export function openSync(path: string, flags: string, mode?: number): number;
+    export function openSync(path: string, flags: string, mode?: string): number;
+    export function utimes(path: string, atime: number, mtime: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function utimes(path: string, atime: Date, mtime: Date, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function utimesSync(path: string, atime: number, mtime: number): void;
+    export function utimesSync(path: string, atime: Date, mtime: Date): void;
+    export function futimes(fd: number, atime: number, mtime: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function futimes(fd: number, atime: Date, mtime: Date, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function futimesSync(fd: number, atime: number, mtime: number): void;
+    export function futimesSync(fd: number, atime: Date, mtime: Date): void;
+    export function fsync(fd: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
+    export function fsyncSync(fd: number): void;
+    export function write(fd: number, buffer: Buffer, offset: number, length: number, position: number, callback?: (err: NodeJS.ErrnoException, written: number, buffer: Buffer) => void): void;
+    export function writeSync(fd: number, buffer: Buffer, offset: number, length: number, position: number): number;
+    export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number, callback?: (err: NodeJS.ErrnoException, bytesRead: number, buffer: Buffer) => void): void;
+    export function readSync(fd: number, buffer: Buffer, offset: number, length: number, position: number): number;
+    export function readFile(filename: string, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
+    export function readFile(filename: string, options: { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
+    export function readFile(filename: string, options: { flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
+    export function readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void ): void;
+    export function readFileSync(filename: string, encoding: string): string;
+    export function readFileSync(filename: string, options: { encoding: string; flag?: string; }): string;
+    export function readFileSync(filename: string, options?: { flag?: string; }): Buffer;
+    export function writeFile(filename: string, data: any, callback?: (err: NodeJS.ErrnoException) => void): void;
+    export function writeFile(filename: string, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
+    export function writeFile(filename: string, data: any, options: { encoding?: string; mode?: string; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
+    export function writeFileSync(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): void;
+    export function writeFileSync(filename: string, data: any, options?: { encoding?: string; mode?: string; flag?: string; }): void;
+    export function appendFile(filename: string, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
+    export function appendFile(filename: string, data: any, options: { encoding?: string; mode?: string; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
+    export function appendFile(filename: string, data: any, callback?: (err: NodeJS.ErrnoException) => void): void;
+    export function appendFileSync(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): void;
+    export function appendFileSync(filename: string, data: any, options?: { encoding?: string; mode?: string; flag?: string; }): void;
+    export function watchFile(filename: string, listener: (curr: Stats, prev: Stats) => void): void;
+    export function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: (curr: Stats, prev: Stats) => void): void;
+    export function unwatchFile(filename: string, listener?: (curr: Stats, prev: Stats) => void): void;
+    export function watch(filename: string, listener?: (event: string, filename: string) => any): FSWatcher;
+    export function watch(filename: string, options: { persistent?: boolean; }, listener?: (event: string, filename: string) => any): FSWatcher;
+    export function exists(path: string, callback?: (exists: boolean) => void): void;
+    export function existsSync(path: string): boolean;
+    export function createReadStream(path: string, options?: {
+        flags?: string;
+        encoding?: string;
+        fd?: string;
+        mode?: number;
+        bufferSize?: number;
+    }): ReadStream;
+    export function createReadStream(path: string, options?: {
+        flags?: string;
+        encoding?: string;
+        fd?: string;
+        mode?: string;
+        bufferSize?: number;
+    }): ReadStream;
+    export function createWriteStream(path: string, options?: {
+        flags?: string;
+        encoding?: string;
+        string?: string;
+    }): WriteStream;
+}
+
+declare module "path" {
+
+    export interface ParsedPath {
+        root: string;
+        dir: string;
+        base: string;
+        ext: string;
+        name: string;
+    }
+
+    export function normalize(p: string): string;
+    export function join(...paths: any[]): string;
+    export function resolve(...pathSegments: any[]): string;
+    export function isAbsolute(p: string): boolean;
+    export function relative(from: string, to: string): string;
+    export function dirname(p: string): string;
+    export function basename(p: string, ext?: string): string;
+    export function extname(p: string): string;
+    export var sep: string;
+    export var delimiter: string;
+    export function parse(p: string): ParsedPath;
+    export function format(pP: ParsedPath): string;
+}
+
+declare module "string_decoder" {
+    export interface NodeStringDecoder {
+        write(buffer: Buffer): string;
+        detectIncompleteChar(buffer: Buffer): number;
+    }
+    export var StringDecoder: {
+        new (encoding: string): NodeStringDecoder;
+    };
+}
+
+declare module "tls" {
+    import crypto = require("crypto");
+    import net = require("net");
+    import stream = require("stream");
+
+    var CLIENT_RENEG_LIMIT: number;
+    var CLIENT_RENEG_WINDOW: number;
+
+    export interface TlsOptions {
+        pfx?: any;   //string or buffer
+        key?: any;   //string or buffer
+        passphrase?: string;
+        cert?: any;
+        ca?: any;    //string or buffer
+        crl?: any;   //string or string array
+        ciphers?: string;
+        honorCipherOrder?: any;
+        requestCert?: boolean;
+        rejectUnauthorized?: boolean;
+        NPNProtocols?: any;  //array or Buffer;
+        SNICallback?: (servername: string) => any;
+    }
+
+    export interface ConnectionOptions {
+        host?: string;
+        port?: number;
+        socket?: net.Socket;
+        pfx?: any;   //string | Buffer
+        key?: any;   //string | Buffer
+        passphrase?: string;
+        cert?: any;  //string | Buffer
+        ca?: any;    //Array of string | Buffer
+        rejectUnauthorized?: boolean;
+        NPNProtocols?: any;  //Array of string | Buffer
+        servername?: string;
+    }
+
+    export interface Server extends net.Server {
+        // Extended base methods
+        listen(port: number, host?: string, backlog?: number, listeningListener?: Function): Server;
+        listen(path: string, listeningListener?: Function): Server;
+        listen(handle: any, listeningListener?: Function): Server;
+
+        listen(port: number, host?: string, callback?: Function): Server;
+        close(): Server;
+        address(): { port: number; family: string; address: string; };
+        addContext(hostName: string, credentials: {
+            key: string;
+            cert: string;
+            ca: string;
+        }): void;
+        maxConnections: number;
+        connections: number;
+    }
+
+    export interface ClearTextStream extends stream.Duplex {
+        authorized: boolean;
+        authorizationError: Error;
+        getPeerCertificate(): any;
+        getCipher: {
+            name: string;
+            version: string;
+        };
+        address: {
+            port: number;
+            family: string;
+            address: string;
+        };
+        remoteAddress: string;
+        remotePort: number;
+    }
+
+    export interface SecurePair {
+        encrypted: any;
+        cleartext: any;
+    }
+
+    export function createServer(options: TlsOptions, secureConnectionListener?: (cleartextStream: ClearTextStream) =>void ): Server;
+    export function connect(options: TlsOptions, secureConnectionListener?: () =>void ): ClearTextStream;
+    export function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () =>void ): ClearTextStream;
+    export function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () =>void ): ClearTextStream;
+    export function createSecurePair(credentials?: crypto.Credentials, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
+}
+
+declare module "crypto" {
+    export interface CredentialDetails {
+        pfx: string;
+        key: string;
+        passphrase: string;
+        cert: string;
+        ca: any;    //string | string array
+        crl: any;   //string | string array
+        ciphers: string;
+    }
+    export interface Credentials { context?: any; }
+    export function createCredentials(details: CredentialDetails): Credentials;
+    export function createHash(algorithm: string): Hash;
+    export function createHmac(algorithm: string, key: string): Hmac;
+    export function createHmac(algorithm: string, key: Buffer): Hmac;
+    interface Hash {
+        update(data: any, input_encoding?: string): Hash;
+        digest(encoding: 'buffer'): Buffer;
+        digest(encoding: string): any;
+        digest(): Buffer;
+    }
+    interface Hmac {
+        update(data: any, input_encoding?: string): Hmac;
+        digest(encoding: 'buffer'): Buffer;
+        digest(encoding: string): any;
+        digest(): Buffer;
+    }
+    export function createCipher(algorithm: string, password: any): Cipher;
+    export function createCipheriv(algorithm: string, key: any, iv: any): Cipher;
+    interface Cipher {
+        update(data: Buffer): Buffer;
+        update(data: string, input_encoding?: string, output_encoding?: string): string;
+        final(): Buffer;
+        final(output_encoding: string): string;
+        setAutoPadding(auto_padding: boolean): void;
+    }
+    export function createDecipher(algorithm: string, password: any): Decipher;
+    export function createDecipheriv(algorithm: string, key: any, iv: any): Decipher;
+    interface Decipher {
+        update(data: Buffer): Buffer;
+        update(data: string, input_encoding?: string, output_encoding?: string): string;
+        final(): Buffer;
+        final(output_encoding: string): string;
+        setAutoPadding(auto_padding: boolean): void;
+    }
+    export function createSign(algorithm: string): Signer;
+    interface Signer {
+        update(data: any): void;
+        sign(private_key: string, output_format: string): string;
+    }
+    export function createVerify(algorith: string): Verify;
+    interface Verify {
+        update(data: any): void;
+        verify(object: string, signature: string, signature_format?: string): boolean;
+    }
+    export function createDiffieHellman(prime_length: number): DiffieHellman;
+    export function createDiffieHellman(prime: number, encoding?: string): DiffieHellman;
+    interface DiffieHellman {
+        generateKeys(encoding?: string): string;
+        computeSecret(other_public_key: string, input_encoding?: string, output_encoding?: string): string;
+        getPrime(encoding?: string): string;
+        getGenerator(encoding: string): string;
+        getPublicKey(encoding?: string): string;
+        getPrivateKey(encoding?: string): string;
+        setPublicKey(public_key: string, encoding?: string): void;
+        setPrivateKey(public_key: string, encoding?: string): void;
+    }
+    export function getDiffieHellman(group_name: string): DiffieHellman;
+    export function pbkdf2(password: string, salt: string, iterations: number, keylen: number, callback: (err: Error, derivedKey: Buffer) => any): void;
+    export function pbkdf2Sync(password: string, salt: string, iterations: number, keylen: number) : Buffer;
+    export function randomBytes(size: number): Buffer;
+    export function randomBytes(size: number, callback: (err: Error, buf: Buffer) =>void ): void;
+    export function pseudoRandomBytes(size: number): Buffer;
+    export function pseudoRandomBytes(size: number, callback: (err: Error, buf: Buffer) =>void ): void;
+}
+
+declare module "stream" {
+    import events = require("events");
+
+    export interface Stream extends events.EventEmitter {
+        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
+    }
+
+    export interface ReadableOptions {
+        highWaterMark?: number;
+        encoding?: string;
+        objectMode?: boolean;
+    }
+
+    export class Readable extends events.EventEmitter implements NodeJS.ReadableStream {
+        readable: boolean;
+        constructor(opts?: ReadableOptions);
+        _read(size: number): void;
+        read(size?: number): string|Buffer;
+        setEncoding(encoding: string): void;
+        pause(): void;
+        resume(): void;
+        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
+        unpipe<T extends NodeJS.WritableStream>(destination?: T): void;
+        unshift(chunk: string): void;
+        unshift(chunk: Buffer): void;
+        wrap(oldStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
+        push(chunk: any, encoding?: string): boolean;
+    }
+
+    export interface WritableOptions {
+        highWaterMark?: number;
+        decodeStrings?: boolean;
+    }
+
+    export class Writable extends events.EventEmitter implements NodeJS.WritableStream {
+        writable: boolean;
+        constructor(opts?: WritableOptions);
+        _write(data: Buffer, encoding: string, callback: Function): void;
+        _write(data: string, encoding: string, callback: Function): void;
+        write(buffer: Buffer, cb?: Function): boolean;
+        write(str: string, cb?: Function): boolean;
+        write(str: string, encoding?: string, cb?: Function): boolean;
+        end(): void;
+        end(buffer: Buffer, cb?: Function): void;
+        end(str: string, cb?: Function): void;
+        end(str: string, encoding?: string, cb?: Function): void;
+    }
+
+    export interface DuplexOptions extends ReadableOptions, WritableOptions {
+        allowHalfOpen?: boolean;
+    }
+
+    // Note: Duplex extends both Readable and Writable.
+    export class Duplex extends Readable implements NodeJS.ReadWriteStream {
+        writable: boolean;
+        constructor(opts?: DuplexOptions);
+        _write(data: Buffer, encoding: string, callback: Function): void;
+        _write(data: string, encoding: string, callback: Function): void;
+        write(buffer: Buffer, cb?: Function): boolean;
+        write(str: string, cb?: Function): boolean;
+        write(str: string, encoding?: string, cb?: Function): boolean;
+        end(): void;
+        end(buffer: Buffer, cb?: Function): void;
+        end(str: string, cb?: Function): void;
+        end(str: string, encoding?: string, cb?: Function): void;
+    }
+
+    export interface TransformOptions extends ReadableOptions, WritableOptions {}
+
+    // Note: Transform lacks the _read and _write methods of Readable/Writable.
+    export class Transform extends events.EventEmitter implements NodeJS.ReadWriteStream {
+        readable: boolean;
+        writable: boolean;
+        constructor(opts?: TransformOptions);
+        _transform(chunk: Buffer, encoding: string, callback: Function): void;
+        _transform(chunk: string, encoding: string, callback: Function): void;
+        _flush(callback: Function): void;
+        read(size?: number): any;
+        setEncoding(encoding: string): void;
+        pause(): void;
+        resume(): void;
+        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
+        unpipe<T extends NodeJS.WritableStream>(destination?: T): void;
+        unshift(chunk: string): void;
+        unshift(chunk: Buffer): void;
+        wrap(oldStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
+        push(chunk: any, encoding?: string): boolean;
+        write(buffer: Buffer, cb?: Function): boolean;
+        write(str: string, cb?: Function): boolean;
+        write(str: string, encoding?: string, cb?: Function): boolean;
+        end(): void;
+        end(buffer: Buffer, cb?: Function): void;
+        end(str: string, cb?: Function): void;
+        end(str: string, encoding?: string, cb?: Function): void;
+    }
+
+    export class PassThrough extends Transform {}
+}
+
+declare module "util" {
+    export interface InspectOptions {
+        showHidden?: boolean;
+        depth?: number;
+        colors?: boolean;
+        customInspect?: boolean;
+    }
+
+    export function format(format: any, ...param: any[]): string;
+    export function debug(string: string): void;
+    export function error(...param: any[]): void;
+    export function puts(...param: any[]): void;
+    export function print(...param: any[]): void;
+    export function log(string: string): void;
+    export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): string;
+    export function inspect(object: any, options: InspectOptions): string;
+    export function isArray(object: any): boolean;
+    export function isRegExp(object: any): boolean;
+    export function isDate(object: any): boolean;
+    export function isError(object: any): boolean;
+    export function inherits(constructor: any, superConstructor: any): void;
+}
+
+declare module "assert" {
+    function internal (value: any, message?: string): void;
+    module internal {
+        export class AssertionError implements Error {
+            name: string;
+            message: string;
+            actual: any;
+            expected: any;
+            operator: string;
+            generatedMessage: boolean;
+
+            constructor(options?: {message?: string; actual?: any; expected?: any;
+                operator?: string; stackStartFunction?: Function});
+        }
+
+        export function fail(actual?: any, expected?: any, message?: string, operator?: string): void;
+        export function ok(value: any, message?: string): void;
+        export function equal(actual: any, expected: any, message?: string): void;
+        export function notEqual(actual: any, expected: any, message?: string): void;
+        export function deepEqual(actual: any, expected: any, message?: string): void;
+        export function notDeepEqual(acutal: any, expected: any, message?: string): void;
+        export function strictEqual(actual: any, expected: any, message?: string): void;
+        export function notStrictEqual(actual: any, expected: any, message?: string): void;
+        export var throws: {
+            (block: Function, message?: string): void;
+            (block: Function, error: Function, message?: string): void;
+            (block: Function, error: RegExp, message?: string): void;
+            (block: Function, error: (err: any) => boolean, message?: string): void;
+        };
+
+        export var doesNotThrow: {
+            (block: Function, message?: string): void;
+            (block: Function, error: Function, message?: string): void;
+            (block: Function, error: RegExp, message?: string): void;
+            (block: Function, error: (err: any) => boolean, message?: string): void;
+        };
+
+        export function ifError(value: any): void;
+    }
+
+    export = internal;
+}
+
+declare module "tty" {
+    import net = require("net");
+
+    export function isatty(fd: number): boolean;
+    export interface ReadStream extends net.Socket {
+        isRaw: boolean;
+        setRawMode(mode: boolean): void;
+    }
+    export interface WriteStream extends net.Socket {
+        columns: number;
+        rows: number;
+    }
+}
+
+declare module "domain" {
+    import events = require("events");
+
+    export class Domain extends events.EventEmitter {
+        run(fn: Function): void;
+        add(emitter: events.EventEmitter): void;
+        remove(emitter: events.EventEmitter): void;
+        bind(cb: (err: Error, data: any) => any): any;
+        intercept(cb: (data: any) => any): any;
+        dispose(): void;
+
+        addListener(event: string, listener: Function): Domain;
+        on(event: string, listener: Function): Domain;
+        once(event: string, listener: Function): Domain;
+        removeListener(event: string, listener: Function): Domain;
+        removeAllListeners(event?: string): Domain;
+    }
+
+    export function create(): Domain;
+}

--- a/javascript/declarations/sockjs-client/sockjs-client.d.ts
+++ b/javascript/declarations/sockjs-client/sockjs-client.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for SockJS 0.3.x
+// Project: https://github.com/sockjs/sockjs-client
+// Definitions by: Emil Ivanov <https://github.com/vladev>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+interface SockJSSimpleEvent {
+    type: string;
+    toString(): string;
+}
+
+interface SJSOpenEvent extends SockJSSimpleEvent {}
+
+interface SJSCloseEvent extends SockJSSimpleEvent {
+    code: number;
+    reason: string;
+    wasClean: boolean;
+}
+
+interface SJSMessageEvent extends SockJSSimpleEvent {
+    data: string;
+}
+
+interface SockJS extends EventTarget {
+    protocol: string;
+    readyState: number;
+    onopen: (ev: SJSOpenEvent) => any;
+    onmessage: (ev: SJSMessageEvent) => any;
+    onclose: (ev: SJSCloseEvent) => any;
+    send(data: any): void;
+    close(code?: number, reason?: string): void;
+    OPEN: number;
+    CLOSING: number;
+    CONNECTING: number;
+    CLOSED: number;
+}
+
+declare var SockJS: {
+    prototype: SockJS;
+    new (url: string, _reserved?: any, options?: {
+        debug?: boolean;
+        devel?: boolean;
+        protocols_whitelist?: string[];
+        server?: string;
+        rtt?: number;
+        rto?: number;
+        info?: {
+            websocket?: boolean;
+            cookie_needed?: boolean;
+            null_origin?: boolean;
+        };
+    }): SockJS;
+};

--- a/javascript/npm-shrinkwrap.json
+++ b/javascript/npm-shrinkwrap.json
@@ -4,59 +4,59 @@
   "dependencies": {
     "browserify": {
       "version": "8.1.3",
-      "from": "browserify@*",
+      "from": "https://registry.npmjs.org/browserify/-/browserify-8.1.3.tgz",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-8.1.3.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.8.4",
-          "from": "JSONStream@>=0.8.3 <0.9.0",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
           "dependencies": {
             "jsonparse": {
               "version": "0.0.5",
-              "from": "jsonparse@0.0.5",
+              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
             },
             "through": {
               "version": "2.3.6",
-              "from": "through@>=2.2.7 <3.0.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "assert": {
           "version": "1.3.0",
-          "from": "assert@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browser-pack": {
           "version": "3.2.0",
-          "from": "browser-pack@>=3.2.0 <4.0.0",
+          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
           "dependencies": {
             "combine-source-map": {
               "version": "0.3.0",
-              "from": "combine-source-map@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
                   "version": "0.3.0",
-                  "from": "inline-source-map@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz"
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
-                  "from": "convert-source-map@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.31 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -65,85 +65,85 @@
             },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
             }
           }
         },
         "browser-resolve": {
           "version": "1.7.0",
-          "from": "browser-resolve@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.7.0.tgz",
           "dependencies": {
             "resolve": {
               "version": "1.1.0",
-              "from": "resolve@1.1.0",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.0.tgz"
             }
           }
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "browserify-zlib@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
               "version": "0.2.5",
-              "from": "pako@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz",
               "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
             }
           }
         },
         "buffer": {
           "version": "3.0.2",
-          "from": "buffer@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-3.0.2.tgz",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.0.2.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "base64-js@0.0.8",
+              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
               "version": "1.1.4",
-              "from": "ieee754@>=1.1.4 <2.0.0",
+              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz",
               "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
             },
             "is-array": {
               "version": "1.0.1",
-              "from": "is-array@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
             }
           }
         },
         "builtins": {
           "version": "0.0.7",
-          "from": "builtins@>=0.0.3 <0.1.0",
+          "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
         },
         "commondir": {
           "version": "0.0.1",
-          "from": "commondir@0.0.1",
+          "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
           "version": "1.4.7",
-          "from": "concat-stream@>=1.4.1 <1.5.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 }
               }
@@ -152,88 +152,88 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "constants-browserify@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
           "version": "3.9.12",
-          "from": "crypto-browserify@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.12.tgz",
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.12.tgz",
           "dependencies": {
             "browserify-aes": {
               "version": "1.0.0",
-              "from": "browserify-aes@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
             },
             "browserify-sign": {
               "version": "2.8.0",
-              "from": "browserify-sign@2.8.0",
+              "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
               "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "browserify-rsa": {
                   "version": "1.1.1",
-                  "from": "browserify-rsa@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
                 },
                 "elliptic": {
                   "version": "1.0.1",
-                  "from": "elliptic@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
                       "version": "1.0.2",
-                      "from": "hash.js@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                     }
                   }
                 },
                 "parse-asn1": {
                   "version": "2.0.0",
-                  "from": "parse-asn1@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
                       "version": "1.0.3",
-                      "from": "asn1.js@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
                     },
                     "asn1.js-rfc3280": {
                       "version": "1.0.0",
-                      "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
                     },
                     "pemstrip": {
                       "version": "0.0.1",
-                      "from": "pemstrip@0.0.1",
+                      "from": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                     }
                   }
@@ -242,27 +242,27 @@
             },
             "create-ecdh": {
               "version": "1.0.3",
-              "from": "create-ecdh@1.0.3",
+              "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.3.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "elliptic": {
                   "version": "1.0.1",
-                  "from": "elliptic@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
                       "version": "1.0.2",
-                      "from": "hash.js@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
                     }
                   }
@@ -271,44 +271,44 @@
             },
             "create-hash": {
               "version": "1.1.0",
-              "from": "create-hash@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
               "dependencies": {
                 "ripemd160": {
                   "version": "1.0.0",
-                  "from": "ripemd160@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
                 },
                 "sha.js": {
                   "version": "2.3.6",
-                  "from": "sha.js@>=2.3.6 <3.0.0",
+                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
                 }
               }
             },
             "create-hmac": {
               "version": "1.1.3",
-              "from": "create-hmac@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
             },
             "diffie-hellman": {
               "version": "3.0.1",
-              "from": "diffie-hellman@>=3.0.1 <4.0.0",
+              "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "miller-rabin": {
                   "version": "1.1.5",
-                  "from": "miller-rabin@>=1.1.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     }
                   }
@@ -317,49 +317,49 @@
             },
             "pbkdf2-compat": {
               "version": "3.0.1",
-              "from": "pbkdf2-compat@>=3.0.1 <4.0.0",
+              "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.1.tgz"
             },
             "public-encrypt": {
               "version": "1.1.2",
-              "from": "public-encrypt@1.1.2",
+              "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.2.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 },
                 "browserify-rsa": {
                   "version": "1.1.1",
-                  "from": "browserify-rsa@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
                 },
                 "parse-asn1": {
                   "version": "2.0.0",
-                  "from": "parse-asn1@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
                   "dependencies": {
                     "asn1.js": {
                       "version": "1.0.3",
-                      "from": "asn1.js@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
                     },
                     "asn1.js-rfc3280": {
                       "version": "1.0.0",
-                      "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
                     },
                     "pemstrip": {
                       "version": "0.0.1",
-                      "from": "pemstrip@0.0.1",
+                      "from": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                     }
                   }
@@ -368,56 +368,56 @@
             },
             "randombytes": {
               "version": "2.0.1",
-              "from": "randombytes@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
             }
           }
         },
         "deep-equal": {
           "version": "0.2.2",
-          "from": "deep-equal@>=0.2.1 <0.3.0",
+          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
         },
         "defined": {
           "version": "0.0.0",
-          "from": "defined@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
           "version": "1.3.5",
-          "from": "deps-sort@>=1.3.5 <2.0.0",
+          "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
             }
           }
         },
         "domain-browser": {
           "version": "1.1.4",
-          "from": "domain-browser@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
         },
         "duplexer2": {
           "version": "0.0.2",
-          "from": "duplexer2@>=0.0.2 <0.1.0",
+          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 }
               }
@@ -426,44 +426,44 @@
         },
         "events": {
           "version": "1.0.2",
-          "from": "events@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
           "version": "4.3.5",
-          "from": "glob@>=4.0.5 <5.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.1",
-              "from": "minimatch@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -472,12 +472,12 @@
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -486,66 +486,66 @@
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "http-browserify@>=1.4.0 <2.0.0",
+          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "Base64@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.1 <2.1.0",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
           "version": "6.2.0",
-          "from": "insert-module-globals@>=6.2.0 <7.0.0",
+          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
           "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.0.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
-              "from": "JSONStream@>=0.7.1 <0.8.0",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 }
               }
             },
             "combine-source-map": {
               "version": "0.3.0",
-              "from": "combine-source-map@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
                   "version": "0.3.0",
-                  "from": "inline-source-map@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.0.tgz"
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
-                  "from": "convert-source-map@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.31 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -554,17 +554,17 @@
             },
             "lexical-scope": {
               "version": "1.1.0",
-              "from": "lexical-scope@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
               "dependencies": {
                 "astw": {
                   "version": "1.1.0",
-                  "from": "astw@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "3001.1.0-dev-harmony-fb",
-                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                     }
                   }
@@ -573,51 +573,51 @@
             },
             "process": {
               "version": "0.6.0",
-              "from": "process@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
             },
             "through": {
               "version": "2.3.6",
-              "from": "through@>=2.3.4 <2.4.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "labeled-stream-splicer": {
           "version": "1.0.2",
-          "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "dependencies": {
             "stream-splicer": {
               "version": "1.3.1",
-              "from": "stream-splicer@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.13-1 <2.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
                 },
                 "readable-wrap": {
                   "version": "1.0.0",
-                  "from": "readable-wrap@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
+                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
@@ -626,101 +626,101 @@
         },
         "module-deps": {
           "version": "3.6.4",
-          "from": "module-deps@>=3.6.3 <4.0.0",
+          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.6.4.tgz",
           "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.6.4.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.7.4",
-              "from": "JSONStream@>=0.7.1 <0.8.0",
+              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
               "dependencies": {
                 "jsonparse": {
                   "version": "0.0.5",
-                  "from": "jsonparse@0.0.5",
+                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@>=2.2.7 <3.0.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "detective": {
               "version": "4.0.0",
-              "from": "detective@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "0.9.0",
-                  "from": "acorn@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
                 },
                 "escodegen": {
                   "version": "1.6.1",
-                  "from": "escodegen@>=1.4.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
                   "dependencies": {
                     "estraverse": {
                       "version": "1.9.1",
-                      "from": "estraverse@>=1.9.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
                     },
                     "esutils": {
                       "version": "1.1.6",
-                      "from": "esutils@>=1.1.6 <2.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                     },
                     "esprima": {
                       "version": "1.2.4",
-                      "from": "esprima@>=1.2.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz"
                     },
                     "optionator": {
                       "version": "0.5.0",
-                      "from": "optionator@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "dependencies": {
                         "prelude-ls": {
                           "version": "1.1.1",
-                          "from": "prelude-ls@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
                         },
                         "deep-is": {
                           "version": "0.1.3",
-                          "from": "deep-is@>=0.1.2 <0.2.0",
+                          "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         },
                         "type-check": {
                           "version": "0.3.1",
-                          "from": "type-check@>=0.3.1 <0.4.0",
+                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                         },
                         "levn": {
                           "version": "0.2.5",
-                          "from": "levn@>=0.2.5 <0.3.0",
+                          "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
                           "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                         },
                         "fast-levenshtein": {
                           "version": "1.0.6",
-                          "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                         }
                       }
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
@@ -731,46 +731,46 @@
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "stream-combiner2": {
               "version": "1.0.2",
-              "from": "stream-combiner2@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "dependencies": {
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
                 }
               }
             },
             "subarg": {
               "version": "0.0.1",
-              "from": "subarg@0.0.1",
+              "from": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.7 <0.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.4.2",
-              "from": "through2@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "dependencies": {
                 "xtend": {
                   "version": "2.1.2",
-                  "from": "xtend@>=2.1.1 <2.2.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                   "dependencies": {
                     "object-keys": {
                       "version": "0.4.0",
-                      "from": "object-keys@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                     }
                   }
@@ -781,212 +781,212 @@
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "os-browserify@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "parents": {
           "version": "1.0.1",
-          "from": "parents@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "dependencies": {
             "path-platform": {
               "version": "0.11.15",
-              "from": "path-platform@>=0.11.15 <0.12.0",
+              "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
             }
           }
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "path-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.10.0",
-          "from": "process@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/process/-/process-0.10.0.tgz",
           "resolved": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
         },
         "punycode": {
           "version": "1.2.4",
-          "from": "punycode@>=1.2.3 <1.3.0",
+          "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
           "version": "1.0.33",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.7.4",
-          "from": "resolve@>=0.7.1 <0.8.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
         },
         "shallow-copy": {
           "version": "0.0.1",
-          "from": "shallow-copy@0.0.1",
+          "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
         },
         "shasum": {
           "version": "1.0.1",
-          "from": "shasum@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "dependencies": {
             "json-stable-stringify": {
               "version": "0.0.1",
-              "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
             },
             "sha.js": {
               "version": "2.3.6",
-              "from": "sha.js@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
             }
           }
         },
         "shell-quote": {
           "version": "0.0.1",
-          "from": "shell-quote@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "subarg": {
           "version": "1.0.0",
-          "from": "subarg@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "1.1.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
             }
           }
         },
         "syntax-error": {
           "version": "1.1.2",
-          "from": "syntax-error@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.9.0",
-              "from": "acorn@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
             }
           }
         },
         "through2": {
           "version": "1.1.1",
-          "from": "through2@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "timers-browserify": {
           "version": "1.3.0",
-          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.3.0.tgz"
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "tty-browserify@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "umd": {
           "version": "2.1.0",
-          "from": "umd@>=2.1.0 <2.2.0",
+          "from": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
           "dependencies": {
             "rfile": {
               "version": "1.0.0",
-              "from": "rfile@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
               "dependencies": {
                 "callsite": {
                   "version": "1.0.0",
-                  "from": "callsite@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                 },
                 "resolve": {
                   "version": "0.3.1",
-                  "from": "resolve@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
                 }
               }
             },
             "ruglify": {
               "version": "1.0.0",
-              "from": "ruglify@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "2.2.5",
-                  "from": "uglify-js@>=2.2.0 <2.3.0",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
                     },
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "optimist@>=0.3.5 <0.4.0",
+                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
@@ -997,46 +997,46 @@
             },
             "through": {
               "version": "2.3.6",
-              "from": "through@>=2.3.4 <2.4.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             },
             "uglify-js": {
               "version": "2.4.16",
-              "from": "uglify-js@>=2.4.0 <2.5.0",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.34",
-                  "from": "source-map@0.1.34",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "optimist": {
                   "version": "0.3.7",
-                  "from": "optimist@>=0.3.5 <0.4.0",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 }
               }
@@ -1045,176 +1045,176 @@
         },
         "url": {
           "version": "0.10.2",
-          "from": "url@>=0.10.1 <0.11.0",
+          "from": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.2.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@1.3.2",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.1 <0.11.0",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "vm-browserify@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "dependencies": {
             "indexof": {
               "version": "0.0.1",
-              "from": "indexof@0.0.1",
+              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             }
           }
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "xtend@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         }
       }
     },
     "crossfilter": {
       "version": "1.3.11",
-      "from": "crossfilter@>=1.3.0 <1.4.0",
+      "from": "https://registry.npmjs.org/crossfilter/-/crossfilter-1.3.11.tgz",
       "resolved": "https://registry.npmjs.org/crossfilter/-/crossfilter-1.3.11.tgz"
     },
     "d3": {
       "version": "3.5.5",
-      "from": "d3@>=3.5.0 <3.6.0",
+      "from": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz"
     },
     "dc": {
       "version": "2.0.0-beta.3",
-      "from": "dc@2.0.0-beta.3",
+      "from": "https://registry.npmjs.org/dc/-/dc-2.0.0-beta.3.tgz",
       "resolved": "https://registry.npmjs.org/dc/-/dc-2.0.0-beta.3.tgz"
     },
     "gulp": {
       "version": "3.8.11",
-      "from": "gulp@*",
+      "from": "https://registry.npmjs.org/gulp/-/gulp-3.8.11.tgz",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.8.11.tgz",
       "dependencies": {
         "archy": {
           "version": "1.0.0",
-          "from": "archy@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "deprecated": {
           "version": "0.0.1",
-          "from": "deprecated@>=0.0.1 <0.0.2",
+          "from": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
         },
         "interpret": {
           "version": "0.3.10",
-          "from": "interpret@>=0.3.2 <0.4.0",
+          "from": "https://registry.npmjs.org/interpret/-/interpret-0.3.10.tgz",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.3.10.tgz"
         },
         "liftoff": {
           "version": "2.0.1",
-          "from": "liftoff@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/liftoff/-/liftoff-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.0.1.tgz",
           "dependencies": {
             "extend": {
               "version": "1.3.0",
-              "from": "extend@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz"
             },
             "findup-sync": {
               "version": "0.2.1",
-              "from": "findup-sync@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@>=4.3.0 <4.4.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.1",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.0",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.2.0",
-                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -1223,12 +1223,12 @@
                     },
                     "once": {
                       "version": "1.3.1",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -1239,39 +1239,39 @@
             },
             "flagged-respawn": {
               "version": "0.3.1",
-              "from": "flagged-respawn@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
             },
             "resolve": {
               "version": "1.0.0",
-              "from": "resolve@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz"
             }
           }
         },
         "minimist": {
           "version": "1.1.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
         },
         "orchestrator": {
           "version": "0.3.7",
-          "from": "orchestrator@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
           "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
           "dependencies": {
             "end-of-stream": {
               "version": "0.1.5",
-              "from": "end-of-stream@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <1.4.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -1280,95 +1280,95 @@
             },
             "sequencify": {
               "version": "0.0.7",
-              "from": "sequencify@>=0.0.7 <0.1.0",
+              "from": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
             },
             "stream-consume": {
               "version": "0.1.0",
-              "from": "stream-consume@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
             }
           }
         },
         "pretty-hrtime": {
           "version": "0.2.2",
-          "from": "pretty-hrtime@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-0.2.2.tgz"
         },
         "semver": {
           "version": "4.3.0",
-          "from": "semver@>=4.1.0 <5.0.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.0.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.0.tgz"
         },
         "tildify": {
           "version": "1.0.0",
-          "from": "tildify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
           "dependencies": {
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             }
           }
         },
         "v8flags": {
           "version": "2.0.2",
-          "from": "v8flags@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.2.tgz"
         },
         "vinyl-fs": {
           "version": "0.3.13",
-          "from": "vinyl-fs@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.13.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.13.tgz",
           "dependencies": {
             "defaults": {
               "version": "1.0.0",
-              "from": "defaults@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/defaults/-/defaults-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.0.tgz",
               "dependencies": {
                 "clone": {
                   "version": "0.1.19",
-                  "from": "clone@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
                   "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
                 }
               }
             },
             "glob-stream": {
               "version": "3.1.18",
-              "from": "glob-stream@>=3.1.5 <4.0.0",
+              "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
               "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@>=4.3.0 <4.4.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.1",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -1377,22 +1377,22 @@
                 },
                 "minimatch": {
                   "version": "2.0.1",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -1401,78 +1401,78 @@
                 },
                 "ordered-read-streams": {
                   "version": "0.1.0",
-                  "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
                 },
                 "glob2base": {
                   "version": "0.0.12",
-                  "from": "glob2base@>=0.0.12 <0.0.13",
+                  "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
                   "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
                   "dependencies": {
                     "find-index": {
                       "version": "0.1.1",
-                      "from": "find-index@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
                     }
                   }
                 },
                 "unique-stream": {
                   "version": "1.0.0",
-                  "from": "unique-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
                 }
               }
             },
             "glob-watcher": {
               "version": "0.0.6",
-              "from": "glob-watcher@>=0.0.6 <0.0.7",
+              "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
               "dependencies": {
                 "gaze": {
                   "version": "0.5.1",
-                  "from": "gaze@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
                   "dependencies": {
                     "globule": {
                       "version": "0.1.0",
-                      "from": "globule@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                       "dependencies": {
                         "lodash": {
                           "version": "1.0.1",
-                          "from": "lodash@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
                         },
                         "glob": {
                           "version": "3.1.21",
-                          "from": "glob@>=3.1.21 <3.2.0",
+                          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "1.2.3",
-                              "from": "graceful-fs@>=1.2.0 <1.3.0",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                             },
                             "inherits": {
                               "version": "1.0.0",
-                              "from": "inherits@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                             }
                           }
                         },
                         "minimatch": {
                           "version": "0.2.14",
-                          "from": "minimatch@>=0.2.11 <0.3.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.5.0",
-                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.0",
-                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                             }
                           }
@@ -1485,90 +1485,90 @@
             },
             "graceful-fs": {
               "version": "3.0.5",
-              "from": "graceful-fs@>=3.0.5 <4.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "strip-bom": {
               "version": "1.0.0",
-              "from": "strip-bom@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
               "dependencies": {
                 "first-chunk-stream": {
                   "version": "1.0.0",
-                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
                 },
                 "is-utf8": {
                   "version": "0.2.0",
-                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.6.3",
-              "from": "through2@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "vinyl": {
               "version": "0.4.6",
-              "from": "vinyl@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
               "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
               "dependencies": {
                 "clone": {
                   "version": "0.2.0",
-                  "from": "clone@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
                 },
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                 }
               }
@@ -1579,115 +1579,115 @@
     },
     "gulp-compile-handlebars": {
       "version": "0.4.4",
-      "from": "gulp-compile-handlebars@*",
+      "from": "https://registry.npmjs.org/gulp-compile-handlebars/-/gulp-compile-handlebars-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/gulp-compile-handlebars/-/gulp-compile-handlebars-0.4.4.tgz",
       "dependencies": {
         "gulp-util": {
           "version": "2.2.20",
-          "from": "gulp-util@>=2.2.10 <2.3.0",
+          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dateformat": {
               "version": "1.0.11",
-              "from": "dateformat@>=1.0.7-1.2.3 <2.0.0",
+              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@*",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.0.0",
-                  "from": "meow@*",
+                  "from": "https://registry.npmjs.org/meow/-/meow-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.0.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.0.2",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.0",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.0",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
                       "dependencies": {
                         "get-stdin": {
                           "version": "3.0.2",
-                          "from": "get-stdin@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
                         },
                         "repeating": {
                           "version": "1.1.1",
-                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.1.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.0",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                             },
                             "meow": {
                               "version": "2.1.0",
-                              "from": "meow@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz"
                             }
                           }
@@ -1696,12 +1696,12 @@
                     },
                     "minimist": {
                       "version": "1.1.0",
-                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
                     },
                     "object-assign": {
                       "version": "2.0.0",
-                      "from": "object-assign@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                     }
                   }
@@ -1710,51 +1710,51 @@
             },
             "lodash._reinterpolate": {
               "version": "2.4.1",
-              "from": "lodash._reinterpolate@>=2.4.1 <3.0.0",
+              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
             },
             "lodash.template": {
               "version": "2.4.1",
-              "from": "lodash.template@>=2.4.1 <3.0.0",
+              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
               "dependencies": {
                 "lodash.defaults": {
                   "version": "2.4.1",
-                  "from": "lodash.defaults@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
                   "dependencies": {
                     "lodash._objecttypes": {
                       "version": "2.4.1",
-                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                     }
                   }
                 },
                 "lodash.escape": {
                   "version": "2.4.1",
-                  "from": "lodash.escape@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
                   "dependencies": {
                     "lodash._escapehtmlchar": {
                       "version": "2.4.1",
-                      "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
                       "dependencies": {
                         "lodash._htmlescapes": {
                           "version": "2.4.1",
-                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
                         }
                       }
                     },
                     "lodash._reunescapedhtml": {
                       "version": "2.4.1",
-                      "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
                       "dependencies": {
                         "lodash._htmlescapes": {
                           "version": "2.4.1",
-                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
                         }
                       }
@@ -1763,39 +1763,39 @@
                 },
                 "lodash._escapestringchar": {
                   "version": "2.4.1",
-                  "from": "lodash._escapestringchar@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
                 },
                 "lodash.keys": {
                   "version": "2.4.1",
-                  "from": "lodash.keys@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "2.4.1",
-                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     },
                     "lodash.isobject": {
                       "version": "2.4.1",
-                      "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                       "dependencies": {
                         "lodash._objecttypes": {
                           "version": "2.4.1",
-                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                         }
                       }
                     },
                     "lodash._shimkeys": {
                       "version": "2.4.1",
-                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
                       "dependencies": {
                         "lodash._objecttypes": {
                           "version": "2.4.1",
-                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                         }
                       }
@@ -1804,54 +1804,54 @@
                 },
                 "lodash.templatesettings": {
                   "version": "2.4.1",
-                  "from": "lodash.templatesettings@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
                 },
                 "lodash.values": {
                   "version": "2.4.1",
-                  "from": "lodash.values@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
                 }
               }
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "multipipe": {
               "version": "0.1.2",
-              "from": "multipipe@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
               "dependencies": {
                 "duplexer2": {
                   "version": "0.0.2",
-                  "from": "duplexer2@0.0.2",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -1862,51 +1862,51 @@
             },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "3.0.0",
-                  "from": "xtend@>=3.0.0 <3.1.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                 }
               }
             },
             "vinyl": {
               "version": "0.2.3",
-              "from": "vinyl@>=0.2.1 <0.3.0",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
               "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
               "dependencies": {
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.1.0",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                 }
               }
@@ -1915,44 +1915,44 @@
         },
         "through2": {
           "version": "0.4.2",
-          "from": "through2@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "2.1.2",
-              "from": "xtend@>=2.1.1 <2.2.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "object-keys@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
@@ -1961,39 +1961,39 @@
         },
         "handlebars": {
           "version": "2.0.0",
-          "from": "handlebars@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "from": "optimist@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.3.6",
-              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -2006,22 +2006,22 @@
     },
     "gulp-concat": {
       "version": "2.4.3",
-      "from": "gulp-concat@*",
+      "from": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.4.3.tgz",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.4.3.tgz",
       "dependencies": {
         "concat-with-sourcemaps": {
           "version": "1.0.0",
-          "from": "concat-with-sourcemaps@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.0.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@>=0.1.41 <0.2.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -2030,119 +2030,119 @@
         },
         "through": {
           "version": "2.3.6",
-          "from": "through@>=2.3.4 <3.0.0",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
         }
       }
     },
     "gulp-debug": {
       "version": "2.0.0",
-      "from": "gulp-debug@*",
+      "from": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-2.0.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "2.0.0",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         },
         "stringify-object": {
           "version": "1.0.0",
-          "from": "stringify-object@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.0.tgz"
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "tildify": {
           "version": "1.0.0",
-          "from": "tildify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
           "dependencies": {
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             }
           }
@@ -2151,42 +2151,42 @@
     },
     "gulp-jshint": {
       "version": "1.9.2",
-      "from": "gulp-jshint@*",
+      "from": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.9.2.tgz",
       "resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.9.2.tgz",
       "dependencies": {
         "jshint": {
           "version": "2.6.0",
-          "from": "jshint@>=2.5.6 <3.0.0",
+          "from": "https://registry.npmjs.org/jshint/-/jshint-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.6.0.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.5",
-              "from": "cli@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.2.1 <3.3.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -2197,44 +2197,44 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
-              "from": "htmlparser2@>=3.8.0 <3.9.0",
+              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
-                  "from": "domhandler@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "entities": {
                           "version": "1.1.1",
-                          "from": "entities@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -2243,100 +2243,100 @@
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.13-1 <2.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "entities@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "shelljs@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "strip-json-comments@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "underscore@>=1.6.0 <1.7.0",
+              "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.2.0",
-          "from": "lodash@>=3.0.1 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
         },
         "minimatch": {
           "version": "2.0.1",
-          "from": "minimatch@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -2345,56 +2345,56 @@
         },
         "rcloader": {
           "version": "0.1.2",
-          "from": "rcloader@0.1.2",
+          "from": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
           "dependencies": {
             "rcfinder": {
               "version": "0.1.8",
-              "from": "rcfinder@>=0.1.6 <0.2.0",
+              "from": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.8.tgz"
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
@@ -2403,142 +2403,142 @@
     },
     "gulp-livereload": {
       "version": "3.7.0",
-      "from": "gulp-livereload@*",
+      "from": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-3.7.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-3.7.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "debug": {
           "version": "2.1.1",
-          "from": "debug@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "event-stream": {
           "version": "3.2.2",
-          "from": "event-stream@>=3.1.7 <4.0.0",
+          "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.2.2.tgz",
           "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.2.2.tgz",
           "dependencies": {
             "through": {
               "version": "2.3.6",
-              "from": "through@>=2.3.1 <2.4.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             },
             "duplexer": {
               "version": "0.1.1",
-              "from": "duplexer@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
             },
             "from": {
               "version": "0.1.3",
-              "from": "from@>=0.0.0 <1.0.0",
+              "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
             },
             "map-stream": {
               "version": "0.1.0",
-              "from": "map-stream@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
             },
             "pause-stream": {
               "version": "0.0.11",
-              "from": "pause-stream@0.0.11",
+              "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
               "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
             },
             "split": {
               "version": "0.3.3",
-              "from": "split@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
               "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
             },
             "stream-combiner": {
               "version": "0.0.4",
-              "from": "stream-combiner@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
             }
           }
         },
         "lodash.assign": {
           "version": "3.0.0",
-          "from": "lodash.assign@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
           "dependencies": {
             "lodash._baseassign": {
               "version": "3.0.1",
-              "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.0.1.tgz",
               "dependencies": {
                 "lodash._basecopy": {
                   "version": "3.0.0",
-                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
                 },
                 "lodash.keys": {
                   "version": "3.0.3",
-                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.3.tgz",
                   "dependencies": {
                     "lodash.isarguments": {
                       "version": "3.0.0",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
                     },
                     "lodash.isarray": {
                       "version": "3.0.0",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
                     },
                     "lodash.isnative": {
                       "version": "3.0.0",
-                      "from": "lodash.isnative@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
                     }
                   }
@@ -2547,17 +2547,17 @@
             },
             "lodash._createassigner": {
               "version": "3.0.0",
-              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.0.0.tgz",
               "dependencies": {
                 "lodash._bindcallback": {
                   "version": "3.0.0",
-                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.0.tgz"
                 },
                 "lodash._isiterateecall": {
                   "version": "3.0.1",
-                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.1.tgz"
                 }
               }
@@ -2566,69 +2566,69 @@
         },
         "tiny-lr": {
           "version": "0.1.5",
-          "from": "tiny-lr@>=0.1.5 <0.2.0",
+          "from": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.1.5.tgz",
           "dependencies": {
             "body-parser": {
               "version": "1.8.4",
-              "from": "body-parser@>=1.8.0 <1.9.0",
+              "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
               "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
               "dependencies": {
                 "bytes": {
                   "version": "1.0.0",
-                  "from": "bytes@1.0.0",
+                  "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
                 },
                 "depd": {
                   "version": "0.4.5",
-                  "from": "depd@0.4.5",
+                  "from": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
                 },
                 "iconv-lite": {
                   "version": "0.4.4",
-                  "from": "iconv-lite@0.4.4",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
                 },
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "media-typer@0.3.0",
+                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "on-finished": {
                   "version": "2.1.0",
-                  "from": "on-finished@2.1.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.0.5",
-                      "from": "ee-first@1.0.5",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "2.2.4",
-                  "from": "qs@2.2.4",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz"
                 },
                 "raw-body": {
                   "version": "1.3.0",
-                  "from": "raw-body@1.3.0",
+                  "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
                 },
                 "type-is": {
                   "version": "1.5.7",
-                  "from": "type-is@>=1.5.1 <1.6.0",
+                  "from": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
                   "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.9",
-                      "from": "mime-types@>=2.0.9 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.7.0",
-                          "from": "mime-db@>=1.7.0 <1.8.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                         }
                       }
@@ -2639,29 +2639,29 @@
             },
             "debug": {
               "version": "2.0.0",
-              "from": "debug@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "faye-websocket": {
               "version": "0.7.3",
-              "from": "faye-websocket@>=0.7.2 <0.8.0",
+              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
               "dependencies": {
                 "websocket-driver": {
                   "version": "0.5.1",
-                  "from": "websocket-driver@>=0.3.6",
+                  "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.1.tgz",
                   "dependencies": {
                     "websocket-extensions": {
                       "version": "0.1.0",
-                      "from": "websocket-extensions@>=0.1.0",
+                      "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.0.tgz"
                     }
                   }
@@ -2670,17 +2670,17 @@
             },
             "livereload-js": {
               "version": "2.2.2",
-              "from": "livereload-js@>=2.2.0 <3.0.0",
+              "from": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
               "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
             },
             "parseurl": {
               "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
             },
             "qs": {
               "version": "2.2.5",
-              "from": "qs@>=2.2.3 <2.3.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz"
             }
           }
@@ -2689,44 +2689,44 @@
     },
     "gulp-react": {
       "version": "2.0.0",
-      "from": "gulp-react@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/gulp-react/-/gulp-react-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-react/-/gulp-react-2.0.0.tgz",
       "dependencies": {
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
@@ -2735,98 +2735,98 @@
     },
     "gulp-rename": {
       "version": "1.2.0",
-      "from": "gulp-rename@*",
+      "from": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.0.tgz"
     },
     "gulp-rev": {
       "version": "3.0.1",
-      "from": "gulp-rev@*",
+      "from": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-3.0.1.tgz",
       "dependencies": {
         "object-assign": {
           "version": "2.0.0",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "vinyl-file": {
           "version": "1.1.1",
-          "from": "vinyl-file@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.1.1.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "3.0.5",
-              "from": "graceful-fs@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
             },
             "strip-bom": {
               "version": "1.0.0",
-              "from": "strip-bom@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
               "dependencies": {
                 "first-chunk-stream": {
                   "version": "1.0.0",
-                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
                 },
                 "is-utf8": {
                   "version": "0.2.0",
-                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                 }
               }
             },
             "vinyl": {
               "version": "0.4.6",
-              "from": "vinyl@>=0.4.3 <0.5.0",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
               "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
               "dependencies": {
                 "clone": {
                   "version": "0.2.0",
-                  "from": "clone@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
                 },
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                 }
               }
@@ -2837,44 +2837,44 @@
     },
     "gulp-rimraf": {
       "version": "0.1.1",
-      "from": "gulp-rimraf@*",
+      "from": "https://registry.npmjs.org/gulp-rimraf/-/gulp-rimraf-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp-rimraf/-/gulp-rimraf-0.1.1.tgz",
       "dependencies": {
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
@@ -2883,107 +2883,107 @@
     },
     "gulp-uglify": {
       "version": "1.1.0",
-      "from": "gulp-uglify@*",
+      "from": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.1.0.tgz",
       "dependencies": {
         "deepmerge": {
           "version": "0.2.7",
-          "from": "deepmerge@>=0.2.7 <0.3.0-0",
+          "from": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.7.tgz",
           "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.7.tgz"
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.1 <1.0.0-0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.4.16",
-          "from": "uglify-js@2.4.16",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.34",
-              "from": "source-map@0.1.34",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             },
             "optimist": {
               "version": "0.3.7",
-              "from": "optimist@>=0.3.5 <0.4.0",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             }
           }
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0-0",
+          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@>=0.1.39 <0.2.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -2994,125 +2994,125 @@
     },
     "gulp-util": {
       "version": "3.0.3",
-      "from": "gulp-util@*",
+      "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.3.tgz",
       "dependencies": {
         "array-differ": {
           "version": "1.0.0",
-          "from": "array-differ@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
         },
         "array-uniq": {
           "version": "1.0.2",
-          "from": "array-uniq@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
         },
         "beeper": {
           "version": "1.0.0",
-          "from": "beeper@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/beeper/-/beeper-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.0.0.tgz"
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "dateformat": {
           "version": "1.0.11",
-          "from": "dateformat@>=1.0.11 <2.0.0",
+          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@*",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.0.0",
-              "from": "meow@*",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.0.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.0.2",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.0",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.0",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
                   "dependencies": {
                     "get-stdin": {
                       "version": "3.0.2",
-                      "from": "get-stdin@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
                     },
                     "repeating": {
                       "version": "1.1.1",
-                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.1.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.0",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                         },
                         "meow": {
                           "version": "2.1.0",
-                          "from": "meow@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz"
                         }
                       }
@@ -3125,120 +3125,120 @@
         },
         "lodash.reescape": {
           "version": "3.0.1",
-          "from": "lodash.reescape@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.reescape/-/lodash.reescape-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.reescape/-/lodash.reescape-3.0.1.tgz",
           "dependencies": {
             "lodash._reescape": {
               "version": "3.0.0",
-              "from": "lodash._reescape@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
             }
           }
         },
         "lodash.reevaluate": {
           "version": "3.0.1",
-          "from": "lodash.reevaluate@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.reevaluate/-/lodash.reevaluate-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.reevaluate/-/lodash.reevaluate-3.0.1.tgz",
           "dependencies": {
             "lodash._reevaluate": {
               "version": "3.0.0",
-              "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
             }
           }
         },
         "lodash.reinterpolate": {
           "version": "3.0.1",
-          "from": "lodash.reinterpolate@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.reinterpolate/-/lodash.reinterpolate-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.reinterpolate/-/lodash.reinterpolate-3.0.1.tgz",
           "dependencies": {
             "lodash._reinterpolate": {
               "version": "3.0.0",
-              "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
             }
           }
         },
         "lodash.template": {
           "version": "3.1.0",
-          "from": "lodash.template@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.1.0.tgz",
           "dependencies": {
             "lodash._basecopy": {
               "version": "3.0.0",
-              "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
             },
             "lodash._baseslice": {
               "version": "3.0.1",
-              "from": "lodash._baseslice@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-3.0.1.tgz"
             },
             "lodash._basetostring": {
               "version": "3.0.0",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
             },
             "lodash._basevalues": {
               "version": "3.0.0",
-              "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
             },
             "lodash._isiterateecall": {
               "version": "3.0.1",
-              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.1.tgz"
             },
             "lodash._reinterpolate": {
               "version": "3.0.0",
-              "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
             },
             "lodash.iserror": {
               "version": "3.0.0",
-              "from": "lodash.iserror@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.iserror/-/lodash.iserror-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.iserror/-/lodash.iserror-3.0.0.tgz"
             },
             "lodash.keys": {
               "version": "3.0.3",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.3.tgz",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.3.tgz",
               "dependencies": {
                 "lodash.isarguments": {
                   "version": "3.0.0",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.0",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
                 },
                 "lodash.isnative": {
                   "version": "3.0.0",
-                  "from": "lodash.isnative@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
                 }
               }
             },
             "lodash.templatesettings": {
               "version": "3.0.1",
-              "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.0.1.tgz",
               "dependencies": {
                 "lodash._reescape": {
                   "version": "3.0.0",
-                  "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
                 },
                 "lodash._reevaluate": {
                   "version": "3.0.0",
-                  "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
                 },
                 "lodash.escape": {
                   "version": "3.0.0",
-                  "from": "lodash.escape@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
                 }
               }
@@ -3247,42 +3247,42 @@
         },
         "minimist": {
           "version": "1.1.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
         },
         "multipipe": {
           "version": "0.1.2",
-          "from": "multipipe@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
           "dependencies": {
             "duplexer2": {
               "version": "0.0.2",
-              "from": "duplexer2@0.0.2",
+              "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -3293,66 +3293,66 @@
         },
         "object-assign": {
           "version": "2.0.0",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         },
         "replace-ext": {
           "version": "0.0.1",
-          "from": "replace-ext@0.0.1",
+          "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "dependencies": {
             "clone": {
               "version": "0.2.0",
-              "from": "clone@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
             },
             "clone-stats": {
               "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
             }
           }
@@ -3361,83 +3361,83 @@
     },
     "jasmine-core": {
       "version": "2.2.0",
-      "from": "jasmine-core@*",
+      "from": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.2.0.tgz"
     },
     "jquery": {
       "version": "2.1.3",
-      "from": "jquery@*",
+      "from": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz"
     },
     "jshint-stylish": {
       "version": "1.0.0",
-      "from": "jshint-stylish@*",
+      "from": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "log-symbols": {
           "version": "1.0.1",
-          "from": "log-symbols@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz"
         },
         "string-length": {
           "version": "1.0.0",
-          "from": "string-length@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
           "dependencies": {
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.0",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
                 }
               }
@@ -3446,76 +3446,76 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "karma": {
       "version": "0.12.31",
-      "from": "karma@*",
+      "from": "https://registry.npmjs.org/karma/-/karma-0.12.31.tgz",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.31.tgz",
       "dependencies": {
         "di": {
           "version": "0.0.1",
-          "from": "di@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
         },
         "socket.io": {
           "version": "0.9.16",
-          "from": "socket.io@0.9.16",
+          "from": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
-              "from": "socket.io-client@0.9.16",
+              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "1.2.5",
-                  "from": "uglify-js@1.2.5",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "ws@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "commander@>=2.1.0 <2.2.0",
+                      "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "nan@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
                       "version": "0.0.6",
-                      "from": "options@>=0.0.5",
+                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     }
                   }
                 },
                 "xmlhttprequest": {
                   "version": "1.4.2",
-                  "from": "xmlhttprequest@1.4.2",
+                  "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
                 },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
-                  "from": "active-x-obfuscator@0.0.1",
+                  "from": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
                       "version": "0.0.5",
-                      "from": "zeparser@0.0.5",
+                      "from": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
@@ -3524,54 +3524,54 @@
             },
             "policyfile": {
               "version": "0.0.4",
-              "from": "policyfile@0.0.4",
+              "from": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
             },
             "base64id": {
               "version": "0.1.0",
-              "from": "base64id@0.1.0",
+              "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "redis": {
               "version": "0.7.3",
-              "from": "redis@0.7.3",
+              "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
               "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
         "chokidar": {
           "version": "0.12.6",
-          "from": "chokidar@>=0.8.2",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
           "dependencies": {
             "readdirp": {
               "version": "1.3.0",
-              "from": "readdirp@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -3580,17 +3580,17 @@
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "fsevents": {
               "version": "0.3.5",
-              "from": "fsevents@>=0.3.1 <0.4.0",
+              "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
               "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
               "dependencies": {
                 "nan": {
                   "version": "1.5.3",
-                  "from": "nan@>=1.5.0 <1.6.0",
+                  "from": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
                 }
               }
@@ -3599,27 +3599,27 @@
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.7 <3.3.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -3628,66 +3628,66 @@
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "http-proxy": {
           "version": "0.10.4",
-          "from": "http-proxy@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
           "dependencies": {
             "pkginfo": {
               "version": "0.3.0",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "utile": {
               "version": "0.2.1",
-              "from": "utile@>=0.2.1 <0.3.0",
+              "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.9 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "deep-equal": {
                   "version": "1.0.0",
-                  "from": "deep-equal@*",
+                  "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
                 },
                 "i": {
                   "version": "0.3.2",
-                  "from": "i@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/i/-/i-0.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.0",
-                  "from": "mkdirp@>=0.0.0 <1.0.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "ncp": {
                   "version": "0.4.2",
-                  "from": "ncp@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                 }
               }
@@ -3696,254 +3696,254 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "q": {
           "version": "0.9.7",
-          "from": "q@>=0.9.7 <0.10.0",
+          "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@>=1.2.11 <1.3.0",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "log4js": {
           "version": "0.6.22",
-          "from": "log4js@>=0.6.3 <0.7.0",
+          "from": "https://registry.npmjs.org/log4js/-/log4js-0.6.22.tgz",
           "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.22.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "1.1.4",
-              "from": "semver@>=1.1.4 <1.2.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
             }
           }
         },
         "useragent": {
           "version": "2.0.10",
-          "from": "useragent@>=2.0.4 <2.1.0",
+          "from": "https://registry.npmjs.org/useragent/-/useragent-2.0.10.tgz",
           "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.10.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
-              "from": "lru-cache@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
             }
           }
         },
         "graceful-fs": {
           "version": "2.0.3",
-          "from": "graceful-fs@>=2.0.1 <2.1.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
         },
         "connect": {
           "version": "2.26.6",
-          "from": "connect@>=2.26.0 <2.27.0",
+          "from": "https://registry.npmjs.org/connect/-/connect-2.26.6.tgz",
           "resolved": "https://registry.npmjs.org/connect/-/connect-2.26.6.tgz",
           "dependencies": {
             "basic-auth-connect": {
               "version": "1.0.0",
-              "from": "basic-auth-connect@1.0.0",
+              "from": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
             },
             "body-parser": {
               "version": "1.8.4",
-              "from": "body-parser@>=1.8.4 <1.9.0",
+              "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
               "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
               "dependencies": {
                 "iconv-lite": {
                   "version": "0.4.4",
-                  "from": "iconv-lite@0.4.4",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
                 },
                 "on-finished": {
                   "version": "2.1.0",
-                  "from": "on-finished@2.1.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.0.5",
-                      "from": "ee-first@1.0.5",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                     }
                   }
                 },
                 "raw-body": {
                   "version": "1.3.0",
-                  "from": "raw-body@1.3.0",
+                  "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
                 }
               }
             },
             "bytes": {
               "version": "1.0.0",
-              "from": "bytes@1.0.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
             },
             "cookie": {
               "version": "0.1.2",
-              "from": "cookie@0.1.2",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
             },
             "cookie-parser": {
               "version": "1.3.3",
-              "from": "cookie-parser@>=1.3.3 <1.4.0",
+              "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.3.tgz"
             },
             "cookie-signature": {
               "version": "1.0.5",
-              "from": "cookie-signature@1.0.5",
+              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
             },
             "compression": {
               "version": "1.1.2",
-              "from": "compression@>=1.1.2 <1.2.0",
+              "from": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.9",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.7.0",
-                          "from": "mime-db@>=1.7.0 <1.8.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
                 },
                 "compressible": {
                   "version": "2.0.2",
-                  "from": "compressible@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.7.0",
-                      "from": "mime-db@>=1.1.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                     }
                   }
                 },
                 "vary": {
                   "version": "1.0.0",
-                  "from": "vary@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
                 }
               }
             },
             "connect-timeout": {
               "version": "1.3.0",
-              "from": "connect-timeout@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "csurf": {
               "version": "1.6.6",
-              "from": "csurf@>=1.6.2 <1.7.0",
+              "from": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
               "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
               "dependencies": {
                 "csrf": {
                   "version": "2.0.5",
-                  "from": "csrf@>=2.0.5 <2.1.0",
+                  "from": "https://registry.npmjs.org/csrf/-/csrf-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.5.tgz",
                   "dependencies": {
                     "base64-url": {
                       "version": "1.2.0",
-                      "from": "base64-url@1.2.0",
+                      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.0.tgz"
                     },
                     "rndm": {
                       "version": "1.1.0",
-                      "from": "rndm@>=1.1.0 <1.2.0",
+                      "from": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz"
                     },
                     "scmp": {
                       "version": "1.0.0",
-                      "from": "scmp@1.0.0",
+                      "from": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
                     },
                     "uid-safe": {
                       "version": "1.0.3",
-                      "from": "uid-safe@>=1.0.3 <1.1.0",
+                      "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.3.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
                           "version": "1.1.2",
-                          "from": "native-or-bluebird@>=1.1.2 <1.2.0",
+                          "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
                         }
                       }
@@ -3952,17 +3952,17 @@
                 },
                 "http-errors": {
                   "version": "1.2.8",
-                  "from": "http-errors@>=1.2.8 <1.3.0",
+                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "statuses": {
                       "version": "1.2.1",
-                      "from": "statuses@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                     }
                   }
@@ -3971,165 +3971,165 @@
             },
             "debug": {
               "version": "2.0.0",
-              "from": "debug@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "depd": {
               "version": "0.4.5",
-              "from": "depd@0.4.5",
+              "from": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz",
               "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
             },
             "errorhandler": {
               "version": "1.2.4",
-              "from": "errorhandler@>=1.2.2 <1.3.0",
+              "from": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.4.tgz",
               "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.4.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.9",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.7.0",
-                          "from": "mime-db@>=1.7.0 <1.8.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
                 },
                 "escape-html": {
                   "version": "1.0.1",
-                  "from": "escape-html@1.0.1",
+                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 }
               }
             },
             "express-session": {
               "version": "1.8.2",
-              "from": "express-session@>=1.8.2 <1.9.0",
+              "from": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
               "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
               "dependencies": {
                 "crc": {
                   "version": "3.0.0",
-                  "from": "crc@3.0.0",
+                  "from": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
                 },
                 "uid-safe": {
                   "version": "1.0.1",
-                  "from": "uid-safe@1.0.1",
+                  "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                   "dependencies": {
                     "mz": {
                       "version": "1.3.0",
-                      "from": "mz@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
                           "version": "1.2.0",
-                          "from": "native-or-bluebird@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
                         },
                         "thenify": {
                           "version": "3.1.0",
-                          "from": "thenify@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz"
                         },
                         "thenify-all": {
                           "version": "1.6.0",
-                          "from": "thenify-all@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
                           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
                         }
                       }
                     },
                     "base64-url": {
                       "version": "1.2.1",
-                      "from": "base64-url@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     }
                   }
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
+                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 }
               }
             },
             "finalhandler": {
               "version": "0.2.0",
-              "from": "finalhandler@0.2.0",
+              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.1",
-                  "from": "escape-html@1.0.1",
+                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 }
               }
             },
             "fresh": {
               "version": "0.2.4",
-              "from": "fresh@0.2.4",
+              "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
               "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
             },
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
+              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "method-override": {
               "version": "2.2.0",
-              "from": "method-override@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
               "dependencies": {
                 "methods": {
                   "version": "1.1.0",
-                  "from": "methods@1.1.0",
+                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
                 },
                 "vary": {
                   "version": "1.0.0",
-                  "from": "vary@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
                 }
               }
             },
             "morgan": {
               "version": "1.3.2",
-              "from": "morgan@>=1.3.2 <1.4.0",
+              "from": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
               "dependencies": {
                 "basic-auth": {
                   "version": "1.0.0",
-                  "from": "basic-auth@1.0.0",
+                  "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
                 },
                 "on-finished": {
                   "version": "2.1.0",
-                  "from": "on-finished@2.1.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.0.5",
-                      "from": "ee-first@1.0.5",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                     }
                   }
@@ -4138,199 +4138,199 @@
             },
             "multiparty": {
               "version": "3.3.2",
-              "from": "multiparty@3.3.2",
+              "from": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
               "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "stream-counter": {
                   "version": "0.2.0",
-                  "from": "stream-counter@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
                 }
               }
             },
             "on-headers": {
               "version": "1.0.0",
-              "from": "on-headers@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
             },
             "parseurl": {
               "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
             },
             "qs": {
               "version": "2.2.4",
-              "from": "qs@2.2.4",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz"
             },
             "response-time": {
               "version": "2.0.1",
-              "from": "response-time@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz"
             },
             "serve-favicon": {
               "version": "2.1.7",
-              "from": "serve-favicon@>=2.1.5 <2.2.0",
+              "from": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
               "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
               "dependencies": {
                 "etag": {
                   "version": "1.5.1",
-                  "from": "etag@>=1.5.0 <1.6.0",
+                  "from": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
                   "dependencies": {
                     "crc": {
                       "version": "3.2.1",
-                      "from": "crc@3.2.1",
+                      "from": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
                     }
                   }
                 },
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "serve-index": {
               "version": "1.2.1",
-              "from": "serve-index@>=1.2.1 <1.3.0",
+              "from": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.9",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.7.0",
-                          "from": "mime-db@>=1.7.0 <1.8.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
                 },
                 "batch": {
                   "version": "0.5.1",
-                  "from": "batch@0.5.1",
+                  "from": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz"
                 }
               }
             },
             "serve-static": {
               "version": "1.6.5",
-              "from": "serve-static@>=1.6.4 <1.7.0",
+              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
               "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.1",
-                  "from": "escape-html@1.0.1",
+                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 },
                 "send": {
                   "version": "0.9.3",
-                  "from": "send@0.9.3",
+                  "from": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.3",
-                      "from": "destroy@1.0.3",
+                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
                     },
                     "etag": {
                       "version": "1.4.0",
-                      "from": "etag@>=1.4.0 <1.5.0",
+                      "from": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
                       "dependencies": {
                         "crc": {
                           "version": "3.0.0",
-                          "from": "crc@3.0.0",
+                          "from": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
                         }
                       }
                     },
                     "ms": {
                       "version": "0.6.2",
-                      "from": "ms@0.6.2",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                     },
                     "on-finished": {
                       "version": "2.1.0",
-                      "from": "on-finished@2.1.0",
+                      "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                       "dependencies": {
                         "ee-first": {
                           "version": "1.0.5",
-                          "from": "ee-first@1.0.5",
+                          "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                         }
                       }
                     },
                     "range-parser": {
                       "version": "1.0.2",
-                      "from": "range-parser@>=1.0.2 <1.1.0",
+                      "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
                     }
                   }
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
+                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 }
               }
             },
             "type-is": {
               "version": "1.5.7",
-              "from": "type-is@>=1.5.2 <1.6.0",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.0.9",
-                  "from": "mime-types@>=2.0.9 <2.1.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.7.0",
-                      "from": "mime-db@>=1.7.0 <1.8.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                     }
                   }
@@ -4339,24 +4339,24 @@
             },
             "vhost": {
               "version": "3.0.0",
-              "from": "vhost@>=3.0.0 <3.1.0",
+              "from": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz"
             },
             "pause": {
               "version": "0.0.1",
-              "from": "pause@0.0.1",
+              "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
             }
           }
         },
         "source-map": {
           "version": "0.1.43",
-          "from": "source-map@>=0.1.31 <0.2.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
@@ -4365,174 +4365,174 @@
     },
     "karma-chrome-launcher": {
       "version": "0.1.7",
-      "from": "karma-chrome-launcher@*",
+      "from": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.7.tgz"
     },
     "karma-html2js-preprocessor": {
       "version": "0.1.0",
-      "from": "karma-html2js-preprocessor@*",
+      "from": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-0.1.0.tgz"
     },
     "karma-jasmine": {
       "version": "0.3.5",
-      "from": "karma-jasmine@*",
+      "from": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz"
     },
     "karma-phantomjs-launcher": {
       "version": "0.1.4",
-      "from": "karma-phantomjs-launcher@*",
+      "from": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz",
       "dependencies": {
         "phantomjs": {
           "version": "1.9.15",
-          "from": "phantomjs@>=1.9.0 <1.10.0",
+          "from": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.15.tgz",
           "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.15.tgz",
           "dependencies": {
             "adm-zip": {
               "version": "0.4.4",
-              "from": "adm-zip@0.4.4",
+              "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
             },
             "fs-extra": {
               "version": "0.16.3",
-              "from": "fs-extra@>=0.16.0 <0.17.0",
+              "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.3.tgz",
               "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.3.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "3.0.5",
-                  "from": "graceful-fs@>=3.0.5 <4.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                 },
                 "jsonfile": {
                   "version": "2.0.0",
-                  "from": "jsonfile@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz"
                 }
               }
             },
             "kew": {
               "version": "0.4.0",
-              "from": "kew@0.4.0",
+              "from": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
             },
             "npmconf": {
               "version": "2.0.9",
-              "from": "npmconf@2.0.9",
+              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.9.tgz",
               "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.9.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.8",
-                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
                   "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
                   "dependencies": {
                     "proto-list": {
                       "version": "1.2.3",
-                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "ini": {
                   "version": "1.3.3",
-                  "from": "ini@>=1.2.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.0",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "nopt": {
                   "version": "3.0.1",
-                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.5",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                     }
                   }
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <1.4.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "osenv": {
                   "version": "0.1.0",
-                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
                 },
                 "semver": {
                   "version": "4.3.0",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.0.tgz"
                 },
                 "uid-number": {
                   "version": "0.0.5",
-                  "from": "uid-number@0.0.5",
+                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
                 }
               }
             },
             "progress": {
               "version": "1.1.8",
-              "from": "progress@1.1.8",
+              "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
               "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
             },
             "request": {
               "version": "2.42.0",
-              "from": "request@2.42.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -4541,161 +4541,161 @@
                 },
                 "caseless": {
                   "version": "0.6.0",
-                  "from": "caseless@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "qs": {
                   "version": "1.2.2",
-                  "from": "qs@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
-                      "from": "punycode@>=0.2.0",
+                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                     }
                   }
                 },
                 "form-data": {
                   "version": "0.1.4",
-                  "from": "form-data@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.2.11",
-                      "from": "mime@>=1.2.11 <1.3.0",
+                      "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                     },
                     "async": {
                       "version": "0.9.0",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                     }
                   }
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "ctype@0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.4.0",
-                  "from": "oauth-sign@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "hawk@1.1.1",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 }
               }
             },
             "request-progress": {
               "version": "0.3.1",
-              "from": "request-progress@0.3.1",
+              "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
               "dependencies": {
                 "throttleit": {
                   "version": "0.0.2",
-                  "from": "throttleit@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
                 }
               }
             },
             "which": {
               "version": "1.0.8",
-              "from": "which@>=1.0.5 <1.1.0",
+              "from": "https://registry.npmjs.org/which/-/which-1.0.8.tgz",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
             }
           }
@@ -4704,17 +4704,17 @@
     },
     "markdown": {
       "version": "0.5.0",
-      "from": "markdown@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
       "dependencies": {
         "nopt": {
           "version": "2.1.2",
-          "from": "nopt@>=2.1.1 <2.2.0",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
@@ -4723,52 +4723,52 @@
     },
     "numeral": {
       "version": "1.5.3",
-      "from": "numeral@>=1.5.0 <1.6.0",
+      "from": "https://registry.npmjs.org/numeral/-/numeral-1.5.3.tgz",
       "resolved": "https://registry.npmjs.org/numeral/-/numeral-1.5.3.tgz"
     },
     "qs": {
       "version": "2.3.3",
-      "from": "qs@>=2.3.0 <2.4.0",
+      "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
     },
     "react": {
       "version": "0.12.2",
-      "from": "react@>=0.12.0 <0.13.0",
+      "from": "https://registry.npmjs.org/react/-/react-0.12.2.tgz",
       "resolved": "https://registry.npmjs.org/react/-/react-0.12.2.tgz",
       "dependencies": {
         "envify": {
           "version": "3.2.0",
-          "from": "envify@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/envify/-/envify-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/envify/-/envify-3.2.0.tgz",
           "dependencies": {
             "through": {
               "version": "2.3.6",
-              "from": "through@>=2.3.4 <2.4.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             },
             "jstransform": {
               "version": "7.0.0",
-              "from": "jstransform@>=7.0.0 <8.0.0",
+              "from": "https://registry.npmjs.org/jstransform/-/jstransform-7.0.0.tgz",
               "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-7.0.0.tgz",
               "dependencies": {
                 "base62": {
                   "version": "0.1.1",
-                  "from": "base62@0.1.1",
+                  "from": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
                 },
                 "esprima-fb": {
                   "version": "7001.1.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=7001.1.0-dev-harmony-fb <7001.2.0",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-7001.1.0-dev-harmony-fb.tgz",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-7001.1.0-dev-harmony-fb.tgz"
                 },
                 "source-map": {
                   "version": "0.1.31",
-                  "from": "source-map@0.1.31",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
@@ -4781,105 +4781,105 @@
     },
     "react-tools": {
       "version": "0.12.2",
-      "from": "react-tools@>=0.12.1 <0.13.0",
+      "from": "https://registry.npmjs.org/react-tools/-/react-tools-0.12.2.tgz",
       "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.12.2.tgz",
       "dependencies": {
         "commoner": {
           "version": "0.10.1",
-          "from": "commoner@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
           "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
           "dependencies": {
             "q": {
               "version": "1.1.2",
-              "from": "q@>=1.1.2 <1.2.0",
+              "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
             },
             "recast": {
               "version": "0.9.18",
-              "from": "recast@>=0.9.5 <0.10.0",
+              "from": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
               "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
               "dependencies": {
                 "esprima-fb": {
                   "version": "10001.1.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=10001.1.0-dev-harmony-fb <10001.2.0",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "ast-types": {
                   "version": "0.6.12",
-                  "from": "ast-types@>=0.6.1 <0.7.0",
+                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.12.tgz",
                   "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.12.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.5.1",
-              "from": "commander@>=2.5.0 <2.6.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
             },
             "graceful-fs": {
               "version": "3.0.5",
-              "from": "graceful-fs@>=3.0.4 <3.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
             },
             "glob": {
               "version": "4.2.2",
-              "from": "glob@>=4.2.1 <4.3.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "1.0.0",
-                  "from": "minimatch@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -4888,56 +4888,56 @@
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "private": {
               "version": "0.1.6",
-              "from": "private@>=0.1.6 <0.2.0",
+              "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
             },
             "install": {
               "version": "0.1.8",
-              "from": "install@>=0.1.7 <0.2.0",
+              "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
             },
             "iconv-lite": {
               "version": "0.4.7",
-              "from": "iconv-lite@>=0.4.5 <0.5.0",
+              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
             }
           }
         },
         "jstransform": {
           "version": "8.2.0",
-          "from": "jstransform@>=8.2.0 <9.0.0",
+          "from": "https://registry.npmjs.org/jstransform/-/jstransform-8.2.0.tgz",
           "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-8.2.0.tgz",
           "dependencies": {
             "base62": {
               "version": "0.1.1",
-              "from": "base62@0.1.1",
+              "from": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
             },
             "esprima-fb": {
               "version": "8001.1001.0-dev-harmony-fb",
-              "from": "esprima-fb@8001.1001.0-dev-harmony-fb",
+              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
               "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
             },
             "source-map": {
               "version": "0.1.31",
-              "from": "source-map@0.1.31",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -4948,69 +4948,165 @@
     },
     "reactify": {
       "version": "1.0.0",
-      "from": "reactify@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/reactify/-/reactify-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/reactify/-/reactify-1.0.0.tgz",
       "dependencies": {
         "through": {
           "version": "2.3.6",
-          "from": "through@>=2.3.4 <3.0.0",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
         }
       }
     },
     "rimraf": {
       "version": "2.2.8",
-      "from": "rimraf@*",
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
     },
     "run-sequence": {
       "version": "1.0.2",
-      "from": "run-sequence@*",
+      "from": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.0.2.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "sockjs-client": {
+      "version": "1.0.0-beta.12",
+      "from": "sockjs-client@1.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.12.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.1.3",
+          "from": "debug@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.0",
+              "from": "ms@0.7.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+            }
+          }
+        },
+        "eventsource": {
+          "version": "0.1.6",
+          "from": "eventsource@>=0.1.3 <0.2.0",
+          "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+          "dependencies": {
+            "original": {
+              "version": "0.0.8",
+              "from": "original@>=0.0.5",
+              "resolved": "https://registry.npmjs.org/original/-/original-0.0.8.tgz",
+              "dependencies": {
+                "url-parse": {
+                  "version": "0.2.3",
+                  "from": "url-parse@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-0.2.3.tgz",
+                  "dependencies": {
+                    "querystringify": {
+                      "version": "0.0.2",
+                      "from": "querystringify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.2.tgz"
+                    },
+                    "requires-port": {
+                      "version": "0.0.0",
+                      "from": "requires-port@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "faye-websocket": {
+          "version": "0.7.3",
+          "from": "faye-websocket@>=0.7.3 <0.8.0",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
+          "dependencies": {
+            "websocket-driver": {
+              "version": "0.5.3",
+              "from": "websocket-driver@>=0.3.6",
+              "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.3.tgz",
+              "dependencies": {
+                "websocket-extensions": {
+                  "version": "0.1.1",
+                  "from": "websocket-extensions@>=0.1.1",
+                  "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "json3": {
+          "version": "3.3.2",
+          "from": "json3@>=3.3.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+        },
+        "url-parse": {
+          "version": "1.0.0",
+          "from": "url-parse@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.0.tgz",
+          "dependencies": {
+            "querystringify": {
+              "version": "0.0.2",
+              "from": "querystringify@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.2.tgz"
+            },
+            "requires-port": {
+              "version": "0.0.0",
+              "from": "requires-port@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.0.tgz"
             }
           }
         }
@@ -5018,59 +5114,59 @@
     },
     "tsify": {
       "version": "0.8.0",
-      "from": "tsify@*",
+      "from": "https://registry.npmjs.org/tsify/-/tsify-0.8.0.tgz",
       "resolved": "https://registry.npmjs.org/tsify/-/tsify-0.8.0.tgz",
       "dependencies": {
         "convert-source-map": {
           "version": "0.4.1",
-          "from": "convert-source-map@>=0.4.1 <0.5.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz"
         },
         "debuglog": {
           "version": "1.0.1",
-          "from": "debuglog@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <3.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.2 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
@@ -5079,61 +5175,61 @@
     },
     "vinyl-source-stream": {
       "version": "1.0.0",
-      "from": "vinyl-source-stream@*",
+      "from": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.0.0.tgz",
       "dependencies": {
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "dependencies": {
             "clone": {
               "version": "0.2.0",
-              "from": "clone@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
             },
             "clone-stats": {
               "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
             }
           }
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
@@ -5142,64 +5238,64 @@
     },
     "watchify": {
       "version": "2.3.0",
-      "from": "watchify@*",
+      "from": "https://registry.npmjs.org/watchify/-/watchify-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-2.3.0.tgz",
       "dependencies": {
         "chokidar": {
           "version": "0.12.6",
-          "from": "chokidar@>=0.12.1 <0.13.0",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
           "dependencies": {
             "readdirp": {
               "version": "1.3.0",
-              "from": "readdirp@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -5208,17 +5304,17 @@
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "fsevents": {
               "version": "0.3.5",
-              "from": "fsevents@>=0.3.1 <0.4.0",
+              "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
               "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
               "dependencies": {
                 "nan": {
                   "version": "1.5.3",
-                  "from": "nan@>=1.5.0 <1.6.0",
+                  "from": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
                 }
               }
@@ -5227,39 +5323,39 @@
         },
         "through2": {
           "version": "0.5.1",
-          "from": "through2@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "3.0.0",
-              "from": "xtend@>=3.0.0 <3.1.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
             }
           }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -15,7 +15,8 @@
     "markdown": "^0.5.0",
     "numeral": "1.5.x",
     "qs": "2.3.x",
-    "react": "0.12.x"
+    "react": "0.12.x",
+    "sockjs-client": "1.0.0-beta.12"
   },
   "devDependencies": {
     "browserify": "*",

--- a/javascript/src/mount.jsx
+++ b/javascript/src/mount.jsx
@@ -16,4 +16,5 @@ $(document).ready(() => {
     if (userPreferences.enableSmartSearch) {
         require('./components/search/mount');
     }
+    require('./stores/metrics/mount');
 });

--- a/javascript/src/stores/metrics/MetricsStore.ts
+++ b/javascript/src/stores/metrics/MetricsStore.ts
@@ -40,7 +40,7 @@ interface Callback {
 }
 
 class MetricsStore {
-    private METRICS_SOCKJS_URL: string = "/a/metrics"; // URLUtils.appPrefixed('/a/metrics');
+    private METRICS_SOCKJS_URL: string = URLUtils.appPrefixed('/a/metrics');
 
     private sock: SockJS;
 

--- a/javascript/src/stores/metrics/MetricsStore.ts
+++ b/javascript/src/stores/metrics/MetricsStore.ts
@@ -1,0 +1,105 @@
+/// <reference path="../../../declarations/node/node.d.ts" />
+/// <reference path="../../../declarations/sockjs-client/sockjs-client.d.ts" />
+
+
+'use strict';
+
+// this is global in top.scala.html
+declare var gl2UserSessionId: string;
+
+var SockJS = require("sockjs-client");
+import UserNotification = require("../../util/UserNotification");
+import URLUtils = require("../../util/URLUtils");
+
+
+interface NamedMetric {
+    name: string;
+    value: any;
+}
+
+interface MetricUpdate {
+    node_id: string;
+    values: Array<NamedMetric>;
+}
+
+interface MetricUpdateCallback {
+    (update: MetricUpdate):void;
+}
+
+interface ListenRequest {
+    nodeId: string;
+    metricNames: Array<string>;
+    callback: MetricUpdateCallback;
+
+}
+
+interface Callback {
+    callback: MetricUpdateCallback;
+    names: {}
+}
+
+class MetricsStore {
+    private METRICS_SOCKJS_URL: string = URLUtils.appPrefixed('/a/metrics');
+
+    private sock: SockJS;
+
+    private callbacks: Array<Callback> = [];
+
+    private isOpen: Boolean = false;
+
+    private queuedRequests: Array<ListenRequest> = [];
+
+    connect() {
+        this.sock = new SockJS(this.METRICS_SOCKJS_URL);
+
+        this.sock.onopen = () => {
+            this.isOpen = true;
+
+            this.sock.send(JSON.stringify({command:"create_session", sessionId:gl2UserSessionId}));
+
+            // callers where potentially queued when they ran before the sockjs connection had been established.
+            // process those first before we continue.
+            this.queuedRequests.forEach((request) => this.registerRequest(request));
+            this.queuedRequests = [];
+
+//            this.sock.send(JSON.stringify({command:"metrics_subscribe", metrics:["org.graylog2.throughput"]}));
+        };
+
+        this.sock.onmessage = (e) => {
+            var update: MetricUpdate = JSON.parse(e.data);
+
+            this.callbacks.forEach((cb) => {
+                // only pass the metrics this caller has asked for, not the entire set
+                var interestingMetrics = update.values.filter((metric) => cb.names.hasOwnProperty(metric.name));
+
+                cb.callback({node_id: update.node_id, values: interestingMetrics});
+            });
+            //console.log('message', e.data);
+        };
+
+        this.sock.onclose = () => {
+            this.isOpen = false;
+            console.log('sockjs connection closed');
+        };
+    }
+
+    listen(request: ListenRequest) {
+        if (this.isOpen) {
+            this.registerRequest(request);
+        } else {
+            this.queuedRequests.push(request);
+        }
+    }
+
+    registerRequest(request: ListenRequest) {
+        var nameMap = {};
+        request.metricNames.forEach((name) => nameMap[name] = 1);
+
+        this.callbacks.push({callback: request.callback, names: nameMap});
+
+        this.sock.send(JSON.stringify({"command":"metrics_subscribe", metrics:request.metricNames }));
+    }
+
+}
+
+export = MetricsStore;

--- a/javascript/src/stores/metrics/mount.jsx
+++ b/javascript/src/stores/metrics/mount.jsx
@@ -1,0 +1,15 @@
+'use strict';
+
+var MetricsStore = require('./MetricsStore');
+
+var metricsStore = new MetricsStore();
+window['metrics'] = metricsStore;
+
+metricsStore.connect();
+
+
+metricsStore.listen({
+    nodeId: "abcd",
+    metricNames: ["org.graylog2.throughput.input.1-sec-rate", "org.graylog2.throughput.output.1-sec-rate"],
+    callback: function(update) { console.log(update); }
+});

--- a/javascript/src/stores/metrics/mount.jsx
+++ b/javascript/src/stores/metrics/mount.jsx
@@ -3,13 +3,15 @@
 var MetricsStore = require('./MetricsStore');
 
 var metricsStore = new MetricsStore();
+// we need a way for legacy js code to access this, so it's global.
 window['metrics'] = metricsStore;
 
 metricsStore.connect();
 
 
+// subscribes on the metrics updates across all nodes (nodeId: null). they get pushed once per second.
 metricsStore.listen({
-    nodeId: "abcd",
+    nodeId: null,
     metricNames: ["org.graylog2.throughput.input.1-sec-rate", "org.graylog2.throughput.output.1-sec-rate"],
     callback: function(update) { console.log(update); }
 });

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -31,6 +31,8 @@ object ApplicationBuild extends Build {
     "com.sun.jersey" % "jersey-grizzly2" % "1.18.1",
     "com.sun.jersey" % "jersey-bundle" % "1.18.1",
 
+    "com.github.fdimuccio" %% "play2-sockjs" % "0.3.1",
+
     "org.mockito" % "mockito-all" % "1.9.5" % "test"
   )
   val repositories = Seq(


### PR DESCRIPTION
In order to get rid of the periodicals.js code, this adds a new store for subscribing callbacks to sets of metrics per graylog server node (or the entire cluster).

Currently one example is hardcoded to demonstrate how the call looks like, but no actual UI updates are performed.
This code needs the https://github.com/Graylog2/graylog2-server/tree/issue-1071 branch of the server to read the global throughput metrics, although you can simply change the mount.jsx to load any other metric, too.