### PR TITLE
Use POST to test extractors

### DIFF
--- a/app/assets/javascripts/extractors.js
+++ b/app/assets/javascripts/extractors.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(document).ready(function () {
 
     $("div.xtrc-select-message").sampleMessageLoader({
         subcontainer: $('div.subcontainer', $('div.xtrc-select-message')),
@@ -9,7 +9,7 @@ $(document).ready(function() {
         selectorButton: $('button.xtrc-load-manual', $('div.subcontainer', $('div.xtrc-select-message')))
     });
 
-    $("div.xtrc-message").on("click", "dt.xtrc-message-field", function() {
+    $("div.xtrc-message").on("click", "dt.xtrc-message-field", function () {
         var field = $(this).attr("data-field");
         var value = $(this).attr("data-value");
         var message = $("div.xtrc-message");
@@ -28,34 +28,71 @@ $(document).ready(function() {
         wizard.show();
     });
 
+    var testExtractor = function (url, data) {
+        return $.ajax({
+            type: "POST",
+            contentType: "application/json",
+            url: appPrefixed(url),
+            data: JSON.stringify(data)
+        });
+    };
+
+    var testRegex = function (regex) {
+        return testExtractor('/a/tools/regex_test', {
+            string: $("#xtrc-example").text(),
+            regex: regex
+        });
+    };
+
+    var testSubstring = function (beginIndex, endIndex) {
+        return testExtractor('/a/tools/substring_test', {
+            string: $("#xtrc-example").text(),
+            start: beginIndex,
+            end: endIndex
+        });
+    };
+
+    var testSplitAndIndex = function (splitBy, index) {
+        return testExtractor('/a/tools/split_and_index_test', {
+            string: $("#xtrc-example").text(),
+            split_by: splitBy,
+            index: index
+        });
+    };
+
+    var testGrok = function (grokPattern) {
+        return testExtractor('/a/tools/grok_test', {
+            string: $("#xtrc-example").text(),
+            pattern: grokPattern
+        });
+    };
+
     // Try regular expression against example.
-    $(".xtrc-try-regex").on("click", function() {
+    $(".xtrc-try-regex").on("click", function () {
         var button = $(this);
 
         button.html("<i class='icon-refresh icon-spin'></i> Trying...");
-        $.ajax({
-            url: appPrefixed('/a/tools/regex_test'),
-            data: {
-                "string":URI.encode($("#xtrc-example").text()),
-                "regex":$("#regex_value").val()
-            },
-            success: function(matchResult) {
-                if (matchResult.finds) {
-                    if (matchResult.match != null) {
-                        highlightMatchResult(matchResult);
-                    } else {
-                        showWarning("Regular expression does not contain any matcher group to extract.");
-                    }
+
+        var promise = testRegex($("#regex_value").val());
+
+        promise.done(function (matchResult) {
+            if (matchResult.finds) {
+                if (matchResult.match != null) {
+                    highlightMatchResult(matchResult);
                 } else {
-                    showWarning("Regular expression did not match.");
+                    showWarning("Regular expression does not contain any matcher group to extract.");
                 }
-            },
-            error: function() {
-                showError("Could not try regular expression. Make sure that it is valid.");
-            },
-            complete: function() {
-                button.html("Try!");
+            } else {
+                showWarning("Regular expression did not match.");
             }
+        });
+
+        promise.fail(function () {
+            showError("Could not try regular expression. Make sure that it is valid.");
+        });
+
+        promise.always(function () {
+            button.html("Try!");
         });
     });
 
@@ -68,36 +105,32 @@ $(document).ready(function() {
         var endIndex = $("#end_index").val();
 
         if (parseInt(beginIndex) == parseInt(endIndex)) {
-            highlightMatchResult({"match": {"start":parseInt(beginIndex), "end":parseInt(endIndex)}});
+            highlightMatchResult({"match": {"start": parseInt(beginIndex), "end": parseInt(endIndex)}});
             return;
         }
 
         button.html("<i class='icon-refresh icon-spin'></i> Trying...");
-        $.ajax({
-            url: appPrefixed('/a/tools/substring_test'),
-            data: {
-                "string":$("#xtrc-example").text(),
-                "start":beginIndex,
-                "end":endIndex
-            },
-            success: function(result) {
-                if(result.successful) {
-                    highlightMatchResult(result);
-                } else {
-                    showWarning(warningText);
-                }
-            },
-            error: function() {
-                showError(warningText);
-            },
-            complete: function() {
-                button.html("Try!");
+        var promise = testSubstring(beginIndex, endIndex);
+
+        promise.done(function (result) {
+            if (result.successful) {
+                highlightMatchResult(result);
+            } else {
+                showWarning(warningText);
             }
+        });
+
+        promise.fail(function () {
+            showError(warningText);
+        });
+
+        promise.always(function () {
+            button.html("Try!");
         });
     }
 
     // Try substring against example.
-    $(".xtrc-try-substring").on("click", function() {
+    $(".xtrc-try-substring").on("click", function () {
         var beginIndex = $("#begin_index");
         var endIndex = $("#end_index");
         var maxLength = $("#xtrc-example").text().length;
@@ -118,32 +151,28 @@ $(document).ready(function() {
     });
 
     // Try split&index against example.
-    $(".xtrc-try-splitandindex").on("click", function() {
+    $(".xtrc-try-splitandindex").on("click", function () {
         var button = $(this);
 
         var warningText = "We were not able to run the split&index extraction. Please check your parameters.";
 
         button.html("<i class='icon-refresh icon-spin'></i> Trying...");
-        $.ajax({
-            url: appPrefixed('/a/tools/split_and_index_test'),
-            data: {
-                "string":$("#xtrc-example").text(),
-                "split_by":$("#split_by").val(),
-                "index":$("#index").val()
-            },
-            success: function(result) {
-                if(result.successful) {
-                    highlightMatchResult(result);
-                } else {
-                    showWarning(warningText);
-                }
-            },
-            error: function() {
-                showError(warningText);
-            },
-            complete: function() {
-                button.html("Try!");
+        var promise = testSplitAndIndex($("#split_by").val(), $("#index").val());
+
+        promise.done(function (result) {
+            if (result.successful) {
+                highlightMatchResult(result);
+            } else {
+                showWarning(warningText);
             }
+        });
+
+        promise.fail(function () {
+            showError(warningText);
+        });
+
+        promise.always(function () {
+            button.html("Try!");
         });
     });
 
@@ -170,50 +199,47 @@ $(document).ready(function() {
     }
 
     // Try grok against example.
-    $(".xtrc-try-grok").on("click", function() {
+    $(".xtrc-try-grok").on("click", function () {
         var button = $(this);
 
         var warningText = "We were not able to run the grok extraction. Please check your parameters.";
 
         button.html("<i class='icon-refresh icon-spin'></i> Trying...");
-        $.ajax({
-            url: appPrefixed('/a/tools/grok_test'),
-            data: {
-                "string":$("#xtrc-example").text(),
-                "pattern":$("#grok_pattern").val()
-            },
-            success: function(result) {
-                if(result.finds) {
-                    showGrokMatches(result);
-                } else {
-                    showWarning(warningText);
-                }
-            },
-            error: function() {
-                showError(warningText);
-            },
-            complete: function() {
-                button.html("Try!");
+        var promise = testGrok($("#grok_pattern").val());
+
+        promise.done(function (result) {
+            if (result.finds) {
+                showGrokMatches(result);
+            } else {
+                showWarning(warningText);
             }
+        });
+
+        promise.fail(function () {
+            showError(warningText);
+        });
+
+        promise.always(function () {
+            button.html("Try!");
         });
     });
 
     function showGrokMatches(result) {
         var fields = $("#grok-matches");
-        
+
         var matchesHtml = "<dl>";
         for (var i = 0; i < result.matches.length; i++) {
-            matchesHtml += "<dt>" + htmlEscape(result.matches[i].name) +"</dt>";
-            matchesHtml += "<dd>" + htmlEscape(result.matches[i].value) +"</dd>";
+            matchesHtml += "<dt>" + htmlEscape(result.matches[i].name) + "</dt>";
+            matchesHtml += "<dd>" + htmlEscape(result.matches[i].value) + "</dd>";
 
         }
         matchesHtml += "</dl>";
-        
+
         fields.html(matchesHtml);
     }
-    
+
     // Add converter button.
-    $("#add-converter-fields button").on("click", function() {
+    $("#add-converter-fields button").on("click", function () {
         var type = $("#add-converter").val();
 
         var converter = $(".xtrc-converter-" + type);
@@ -224,25 +250,25 @@ $(document).ready(function() {
     });
 
     // Only allow alphanum and underscores as target_field values. Messages in graylog2-server will just ignore others.
-    $("#target_field").on("keyup", function(event){
+    $("#target_field").on("keyup", function (event) {
         var str = $(this).val();
-        if(str != "") {
+        if (str != "") {
             var regex = /^[A-Za-z0-9_]+$/;
             if (!regex.test(str)) {
-                $(this).val(str.slice(0,-1));
+                $(this).val(str.slice(0, -1));
                 return false;
             }
         }
     });
 
     // Show extractor details.
-    $(".extractor-show-details, .xtrc-exception-bubble").on("click", function() {
+    $(".extractor-show-details, .xtrc-exception-bubble").on("click", function () {
         var extractorId = $(this).attr("data-extractor-id");
         $(".extractor-details-" + extractorId).toggle();
     });
 
     function activateCheckedConditionTypeForm(input) {
-        switch(input.val()) {
+        switch (input.val()) {
             case "none":
                 noConditionTypeChecked();
                 break;
@@ -284,41 +310,39 @@ $(document).ready(function() {
         activateCheckedConditionTypeForm(checkedConditionType);
     }
 
-    $(".extractor-form input[name='condition_type']").on("change", function(event) {
+    $(".extractor-form input[name='condition_type']").on("change", function (event) {
         activateCheckedConditionTypeForm($(event.target));
     });
 
     // Try regex conditions.
-    $(".try-xtrc-condition").on("click", function() {
+    $(".try-xtrc-condition").on("click", function () {
         var button = $(this);
 
         button.html("<i class='icon-refresh icon-spin'></i> Trying...");
-        $.ajax({
-            url: appPrefixed('/a/tools/regex_test'),
-            data: {
-                "string":$("#xtrc-example").text(),
-                "regex":$("#condition_value").val()
-            },
-            success: function(matchResult) {
-                var resultMsg = $("#try-xtrc-condition-result");
-                resultMsg.removeClass("success-match");
-                resultMsg.removeClass("fail-match");
-                if(matchResult.finds) {
-                    resultMsg.html("Matches! Extractor would run against this example.");
-                    resultMsg.addClass("success-match");
-                } else {
-                    resultMsg.html("Does not match! Extractor would not run.");
-                    resultMsg.addClass("fail-match");
-                }
 
-                resultMsg.show();
-            },
-            error: function() {
-                showError("Could not try regular expression. Make sure that it is valid.");
-            },
-            complete: function() {
-                button.html("Try!");
+        var promise = testRegex($("#condition_value").val());
+
+        promise.done(function (matchResult) {
+            var resultMsg = $("#try-xtrc-condition-result");
+            resultMsg.removeClass("success-match");
+            resultMsg.removeClass("fail-match");
+            if (matchResult.finds) {
+                resultMsg.html("Matches! Extractor would run against this example.");
+                resultMsg.addClass("success-match");
+            } else {
+                resultMsg.html("Does not match! Extractor would not run.");
+                resultMsg.addClass("fail-match");
             }
+
+            resultMsg.show();
+        });
+
+        promise.fail(function () {
+            showError("Could not try regular expression. Make sure that it is valid.");
+        });
+
+        promise.always(function () {
+            button.html("Try!");
         });
     });
 
@@ -331,13 +355,13 @@ $(document).ready(function() {
         cursor: "move",
         tolerance: "intersect",
         containment: "parent",
-        start: function(event, ui) {
+        start: function (event, ui) {
             ui.item.toggleClass("xtrc-order-active");
         },
-        stop: function(event, ui) {
+        stop: function (event, ui) {
             ui.item.toggleClass("xtrc-order-active");
         },
-        update: function(event, ui) {
+        update: function (event, ui) {
             var sorted = $(this).sortable("toArray");
             var inputPersistId = $(this).attr("data-input-persist-id");
             var body = {
@@ -350,10 +374,10 @@ $(document).ready(function() {
                 data: JSON.stringify(body),
                 processData: false,
                 contentType: 'application/json',
-                success: function() {
+                success: function () {
                     showSuccess("Extractor positions updated.")
                 },
-                error: function() {
+                error: function () {
                     showError("Could not update extractor order. Please try again.");
                 }
             });
@@ -362,9 +386,10 @@ $(document).ready(function() {
     });
 
     // Extractor export formatting.
-    if($(".extractor-json").size() > 0) {
+    if ($(".extractor-json").size() > 0) {
         var formatted = JSON.stringify(JSON.parse($(".extractor-json").val()), null, 2);
         $(".extractor-json").val(formatted);
     }
 
-});
+})
+;

--- a/app/controllers/api/ToolsApiController.java
+++ b/app/controllers/api/ToolsApiController.java
@@ -1,6 +1,4 @@
-/*
- * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
- *
+/**
  * This file is part of Graylog.
  *
  * Graylog is free software: you can redistribute it and/or modify
@@ -16,8 +14,10 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package controllers.api;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import controllers.AuthenticatedController;
 import lib.NaturalDateTest;
@@ -26,6 +26,10 @@ import lib.extractors.testers.RegexTest;
 import lib.extractors.testers.SplitAndIndexTest;
 import lib.extractors.testers.SubstringTest;
 import org.graylog2.restclient.lib.APIException;
+import org.graylog2.restclient.models.api.requests.tools.RegexTestRequest;
+import org.graylog2.restclient.models.api.requests.tools.GrokTestRequest;
+import org.graylog2.restclient.models.api.requests.tools.SplitAndIndexTestRequest;
+import org.graylog2.restclient.models.api.requests.tools.SubstringTestRequest;
 import play.libs.Json;
 import play.mvc.Result;
 
@@ -52,13 +56,16 @@ public class ToolsApiController extends AuthenticatedController {
         this.grokTest = grokTest;
     }
 
-    public Result regexTest(String regex, String string) {
+    public Result regexTest() {
+        final JsonNode json = request().body().asJson();
+        final RegexTestRequest request = Json.fromJson(json, RegexTestRequest.class);
+
         try {
-            if (regex.isEmpty() || string.isEmpty()) {
+            if (request.regex.isEmpty() || request.string.isEmpty()) {
                 return badRequest();
             }
 
-            return ok(Json.toJson(regexTest.test(regex, string)));
+            return ok(Json.toJson(regexTest.test(request)));
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -66,13 +73,15 @@ public class ToolsApiController extends AuthenticatedController {
         }
     }
 
-    public Result substringTest(int start, int end, String string) {
+    public Result substringTest() {
+        final JsonNode json = request().body().asJson();
+        final SubstringTestRequest request = Json.fromJson(json, SubstringTestRequest.class);
         try {
-            if (start < 0 || end <= 0 || string.isEmpty()) {
+            if (request.start < 0 || request.end <= 0 || request.string.isEmpty()) {
                 return badRequest();
             }
 
-            return ok(Json.toJson(substringTest.test(start, end, string)));
+            return ok(Json.toJson(substringTest.test(request)));
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -80,13 +89,16 @@ public class ToolsApiController extends AuthenticatedController {
         }
     }
 
-    public Result splitAndIndexTest(String splitBy, int index, String string) {
+    public Result splitAndIndexTest() {
+        final JsonNode json = request().body().asJson();
+        final SplitAndIndexTestRequest request = Json.fromJson(json, SplitAndIndexTestRequest.class);
+
         try {
-            if (splitBy.isEmpty() || index < 0 || string.isEmpty()) {
+            if (request.splitBy.isEmpty() || request.index < 0 || request.string.isEmpty()) {
                 return badRequest();
             }
 
-            return ok(Json.toJson(splitAndIndexTest.test(splitBy, index, string)));
+            return ok(Json.toJson(splitAndIndexTest.test(request)));
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -111,13 +123,16 @@ public class ToolsApiController extends AuthenticatedController {
         }
     }
 
-    public Result grokTest(String pattern, String string) {
-        if (pattern.isEmpty() || string.isEmpty()) {
+    public Result grokTest() {
+        final JsonNode json = request().body().asJson();
+        final GrokTestRequest request = Json.fromJson(json, GrokTestRequest.class);
+
+        if (request.pattern.isEmpty() || request.string.isEmpty()) {
             return badRequest();
         }
 
         try {
-            return ok(Json.toJson(grokTest.test(pattern, string)));
+            return ok(Json.toJson(grokTest.test(request)));
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/lib/extractors/testers/GrokTest.java
+++ b/app/lib/extractors/testers/GrokTest.java
@@ -1,6 +1,4 @@
-/*
- * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
- *
+/**
  * This file is part of Graylog.
  *
  * Graylog is free software: you can redistribute it and/or modify
@@ -16,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package lib.extractors.testers;
 
 import com.google.common.collect.FluentIterable;
@@ -25,6 +24,7 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
+import org.graylog2.restclient.models.api.requests.tools.GrokTestRequest;
 import org.graylog2.restclient.models.api.responses.GrokTestResponse;
 
 import java.io.IOException;
@@ -33,9 +33,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public class GrokTest {
 
     private final ApiClient api;
@@ -45,11 +42,10 @@ public class GrokTest {
         this.api = api;
     }
 
-    public Map<String, Object> test(String pattern, String string) throws IOException, APIException {
-        GrokTestResponse r = api.get(GrokTestResponse.class)
+    public Map<String, Object> test(GrokTestRequest request) throws IOException, APIException {
+        GrokTestResponse r = api.post(GrokTestResponse.class)
                 .path("/tools/grok_tester")
-                .queryParam("pattern", pattern)
-                .queryParam("string", string)
+                .body(request)
                 .execute();
 
         ArrayList<Object> matches = Lists.newArrayList();

--- a/app/lib/extractors/testers/RegexTest.java
+++ b/app/lib/extractors/testers/RegexTest.java
@@ -1,6 +1,4 @@
-/*
- * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
- *
+/**
  * This file is part of Graylog.
  *
  * Graylog is free software: you can redistribute it and/or modify
@@ -16,20 +14,19 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package lib.extractors.testers;
 
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
+import org.graylog2.restclient.models.api.requests.tools.RegexTestRequest;
 import org.graylog2.restclient.models.api.responses.RegexTestResponse;
 
 import java.io.IOException;
 import java.util.Map;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public class RegexTest {
 
     private final ApiClient api;
@@ -39,11 +36,10 @@ public class RegexTest {
         this.api = api;
     }
 
-    public Map<String, Object> test(String regex, String string) throws IOException, APIException {
-        RegexTestResponse r = api.get(RegexTestResponse.class)
+    public Map<String, Object> test(RegexTestRequest request) throws IOException, APIException {
+        RegexTestResponse r = api.post(RegexTestResponse.class)
                 .path("/tools/regex_tester")
-                .queryParam("regex", regex)
-                .queryParam("string", string)
+                .body(request)
                 .execute();
 
         Map<String, Object> result = Maps.newHashMap();
@@ -62,5 +58,4 @@ public class RegexTest {
 
         return result;
     }
-
 }

--- a/app/lib/extractors/testers/SplitAndIndexTest.java
+++ b/app/lib/extractors/testers/SplitAndIndexTest.java
@@ -1,6 +1,4 @@
-/*
- * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
- *
+/**
  * This file is part of Graylog.
  *
  * Graylog is free software: you can redistribute it and/or modify
@@ -16,20 +14,19 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package lib.extractors.testers;
 
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
+import org.graylog2.restclient.models.api.requests.tools.SplitAndIndexTestRequest;
 import org.graylog2.restclient.models.api.responses.SplitAndIndexTestResponse;
 
 import java.io.IOException;
 import java.util.Map;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public class SplitAndIndexTest {
 
     private final ApiClient api;
@@ -39,15 +36,11 @@ public class SplitAndIndexTest {
         this.api = api;
     }
 
-    public Map<String, Object> test(String splitBy, int index, String string) throws IOException, APIException {
-        SplitAndIndexTestResponse r = api.get(SplitAndIndexTestResponse.class)
+    public Map<String, Object> test(SplitAndIndexTestRequest request) throws IOException, APIException {
+        SplitAndIndexTestResponse r = api.post(SplitAndIndexTestResponse.class)
                 .path("/tools/split_and_index_tester")
-                .queryParam("split_by", splitBy)
-                .queryParam("index", index)
-                .queryParam("string", string)
+                .body(request)
                 .execute();
-
-                //Api.get(part, SplitAndIndexTestResponse.class);
 
         Map<String, Object> match = Maps.newHashMap();
         match.put("start", r.beginIndex);

--- a/app/lib/extractors/testers/SubstringTest.java
+++ b/app/lib/extractors/testers/SubstringTest.java
@@ -1,6 +1,4 @@
-/*
- * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
- *
+/**
  * This file is part of Graylog.
  *
  * Graylog is free software: you can redistribute it and/or modify
@@ -16,20 +14,19 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package lib.extractors.testers;
 
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
+import org.graylog2.restclient.models.api.requests.tools.SubstringTestRequest;
 import org.graylog2.restclient.models.api.responses.SubstringTestResponse;
 
 import java.io.IOException;
 import java.util.Map;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public class SubstringTest {
 
 
@@ -40,12 +37,10 @@ public class SubstringTest {
         this.api = api;
     }
 
-    public Map<String, Object> test(int start, int end, String string) throws IOException, APIException {
-        SubstringTestResponse r = api.get(SubstringTestResponse.class)
+    public Map<String, Object> test(SubstringTestRequest request) throws IOException, APIException {
+        SubstringTestResponse r = api.post(SubstringTestResponse.class)
                 .path("/tools/substring_tester")
-                .queryParam("begin_index", start)
-                .queryParam("end_index", end)
-                .queryParam("string", string)
+                .body(request)
                 .execute();
 
         Map<String, Object> match = Maps.newHashMap();

--- a/conf/routes
+++ b/conf/routes
@@ -213,11 +213,11 @@ GET         /a/messages/:index/:id                                              
 GET         /a/messages/:index/:id/filtered                                          @controllers.MessagesController.single(index: String, id: String, filtered: Boolean ?= true)
 
 # API: Tools
-GET         /a/tools/regex_test                                                      @controllers.api.ToolsApiController.regexTest(regex ?= "", string ?= "")
-GET         /a/tools/substring_test                                                  @controllers.api.ToolsApiController.substringTest(start:Integer ?= 0, end:Integer ?= 0, string ?= "")
-GET         /a/tools/split_and_index_test                                            @controllers.api.ToolsApiController.splitAndIndexTest(split_by:String ?= "", index:Integer ?= 0, string ?= "")
+POST        /a/tools/regex_test                                                      @controllers.api.ToolsApiController.regexTest()
+POST        /a/tools/substring_test                                                  @controllers.api.ToolsApiController.substringTest()
+POST        /a/tools/split_and_index_test                                            @controllers.api.ToolsApiController.splitAndIndexTest()
+POST        /a/tools/grok_test                                                       @controllers.api.ToolsApiController.grokTest()
 GET         /a/tools/natural_date_test                                               @controllers.api.ToolsApiController.naturalDateTest(string ?= "")
-GET         /a/tools/grok_test                                                       @controllers.api.ToolsApiController.grokTest(pattern ?= "", string ?= "")
 
 # API: Server Connection
 GET         /a/connection/available                                                  @controllers.LonesomeInterfaceController.checkServerAvailability()


### PR DESCRIPTION
Use POST to test extractors, being able to use longer example messages and also helping with encoding issues. Fixes #1190.

Need these changes to work:  https://github.com/Graylog2/graylog2-server/pull/1090