### PR TITLE
Fix potential NPEs in DateHelper

### DIFF
--- a/app/views/helpers/DateHelper.java
+++ b/app/views/helpers/DateHelper.java
@@ -25,21 +25,26 @@ import org.joda.time.Duration;
 import org.joda.time.format.PeriodFormat;
 import org.joda.time.format.PeriodFormatter;
 import play.twirl.api.Html;
+import play.twirl.api.HtmlFormat;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public class DateHelper {
-
     public static Html current() {
         return timestamp(DateTime.now());
     }
 
     public static Html timestamp(DateTime instant) {
+        if (instant == null) {
+            return HtmlFormat.empty();
+        }
+
         return views.html.partials.dates.instant.render(DateTools.inUserTimeZone(instant), DateTools.DEFAULT_DATE_FORMAT);
     }
 
     public static Html timestampShort(DateTime instant) {
+        if (instant == null) {
+            return HtmlFormat.empty();
+        }
+
         return views.html.partials.dates.instant.render(DateTools.inUserTimeZone(instant), DateTools.SHORT_DATE_FORMAT);
     }
 
@@ -48,12 +53,11 @@ public class DateHelper {
     }
 
     public static Html timestampShortTZ(DateTime instant, boolean inUserTZ) {
-        DateTime date = instant;
-
-        if (inUserTZ) {
-            date = DateTools.inUserTimeZone(instant);
+        if (instant == null) {
+            return HtmlFormat.empty();
         }
-        return views.html.partials.dates.instant.render(date, DateTools.SHORT_DATE_FORMAT_TZ);
+
+        return views.html.partials.dates.instant.render(inUserTZ ? DateTools.inUserTimeZone(instant) : instant, DateTools.SHORT_DATE_FORMAT_TZ);
     }
 
     public static Html readablePeriodFromNow(DateTime instant) {
@@ -61,13 +65,18 @@ public class DateHelper {
     }
 
     public static Html readablePeriodFromNow(DateTime instant, String classes) {
+        if (instant == null) {
+            return HtmlFormat.empty();
+        }
+
         return views.html.partials.dates.readable_period.render(DateTools.inUserTimeZone(instant), classes);
     }
 
     public static Html readableDuration(Duration duration) {
-        PeriodFormatter formatter = PeriodFormat.getDefault();
+        if (duration == null) {
+            return HtmlFormat.empty();
+        }
 
-        return views.html.partials.dates.duration.render(duration, formatter);
-        
+        return views.html.partials.dates.duration.render(duration, PeriodFormat.getDefault());
     }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -33,7 +33,9 @@ object ApplicationBuild extends Build {
 
     "com.github.fdimuccio" %% "play2-sockjs" % "0.3.1",
 
-    "org.mockito" % "mockito-all" % "1.9.5" % "test"
+    "junit" % "junit" % "4.12" % "test",
+    "org.mockito" % "mockito-all" % "1.9.5" % "test",
+    "org.assertj" % "assertj-core" % "2.0.0" % "test"
   )
   val repositories = Seq(
     Resolver.mavenLocal,

--- a/test/views/helpers/DateHelperTest.java
+++ b/test/views/helpers/DateHelperTest.java
@@ -1,0 +1,91 @@
+package views.helpers;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DateHelperTest {
+    private static final Locale DEFAULT_LOCALE = Locale.getDefault();
+
+    @BeforeClass
+    public static void setUp() {
+        Locale.setDefault(Locale.ENGLISH);
+        DateTimeUtils.setCurrentMillisFixed(0L);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Locale.setDefault(DEFAULT_LOCALE);
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test
+    public void testCurrent() throws Exception {
+        assertThat(DateHelper.current().body())
+                .contains("1970-01-01T00:00:00.000Z")
+                .contains("Thu Jan 01 1970 00:00:00.000 +00:00")
+                .endsWith("</time>");
+    }
+
+    @Test
+    public void testTimestamp() throws Exception {
+        assertThat(DateHelper.timestamp(null).body())
+                .isEmpty();
+        assertThat(DateHelper.timestamp(DateTime.now(DateTimeZone.UTC)).body())
+                .contains("1970-01-01T00:00:00.000Z")
+                .endsWith("</time>");
+    }
+
+    @Test
+    public void testTimestampShort() throws Exception {
+        assertThat(DateHelper.timestampShort(null).body())
+                .isEmpty();
+        assertThat(DateHelper.timestampShort(DateTime.now(DateTimeZone.UTC)).body())
+                .contains("1970-01-01T00:00:00.000Z")
+                .endsWith("</time>");
+    }
+
+    @Test
+    public void testTimestampShortTZ() throws Exception {
+        assertThat(DateHelper.timestampShortTZ(null).body())
+                .isEmpty();
+        assertThat(DateHelper.timestampShortTZ(null, true).body())
+                .isEmpty();
+        assertThat(DateHelper.timestampShortTZ(null, false).body())
+                .isEmpty();
+        assertThat(DateHelper.timestampShortTZ(DateTime.now(DateTimeZone.UTC), true).body())
+                .contains("1970-01-01T00:00:00.000Z")
+                .endsWith("</time>");
+        assertThat(DateHelper.timestampShortTZ(DateTime.now(DateTimeZone.UTC), false).body())
+                .contains("1970-01-01T00:00:00.000Z")
+                .endsWith("</time>");
+    }
+
+    @Test
+    public void testReadablePeriodFromNow() throws Exception {
+        assertThat(DateHelper.readablePeriodFromNow(null).body())
+                .isEmpty();
+        assertThat(DateHelper.readablePeriodFromNow(DateTime.now(DateTimeZone.UTC)).body())
+                .contains("1970-01-01T00:00:00.000Z")
+                .endsWith("</time>");
+    }
+
+    @Test
+    public void testReadableDuration() throws Exception {
+        assertThat(DateHelper.readableDuration(null).body())
+                .isEmpty();
+        assertThat(DateHelper.readableDuration(Duration.standardHours(1L)).body())
+                .contains("1 hour")
+                .endsWith("</time>");
+    }
+}


### PR DESCRIPTION
The Kruschtel-Klasse `DateHelper` was prone to throwing NPEs if arguments of the helper methods were `null`.

The methods now return an empty `Html` partial instead of throwing a NullPointerException.