### PR TITLE
Refactor stream buttons.

### DIFF
--- a/app/assets/stylesheets/graylog2.less
+++ b/app/assets/stylesheets/graylog2.less
@@ -3088,3 +3088,8 @@ div.alerts-container .dynatable-search {
   margin-right: 5px;
   margin-left: 2px;
 }
+
+// Ensure that the stream start/pause buttons have the same size.
+.toggle-stream-button {
+  width: 8.5em;
+}

--- a/javascript/src/components/streams/Stream.jsx
+++ b/javascript/src/components/streams/Stream.jsx
@@ -17,16 +17,13 @@ var Stream = React.createClass({
     _formatNumberOfStreamRules(stream) {
         return (stream.stream_rules.length > 0 ? stream.stream_rules.length + " configured stream rule(s)." : "no configured rules.");
     },
-    _handleDelete() {
-        this._onDelete(this.props.stream);
-    },
     _onDelete(stream) {
         if (window.confirm("Do you really want to remove this stream?")) {
             StreamsStore.remove(stream.id, () => {});
         }
     },
-    _onResume(stream) {
-        StreamsStore.resume(stream.id, () => {});
+    _onResume(evt) {
+        StreamsStore.resume(this.props.stream.id, () => {});
     },
     _onUpdate(streamId, stream) {
         StreamsStore.update(streamId, stream, () => {});
@@ -34,9 +31,9 @@ var Stream = React.createClass({
     _onClone(streamId, stream) {
         StreamsStore.cloneStream(streamId, stream, () => {});
     },
-    _onPause(stream) {
-        if (window.confirm("Do you really want to pause stream \"" + stream.title + "\"?")) {
-            StreamsStore.pause(stream.id, () => {});
+    _onPause(evt) {
+        if (window.confirm("Do you really want to pause stream \"" + this.props.stream.title + "\"?")) {
+            StreamsStore.pause(this.props.stream.id, () => {});
         }
     },
     _onQuickAdd() {
@@ -59,9 +56,14 @@ var Stream = React.createClass({
                                       className="btn btn-info">Manage alerts</a>;
         }
 
-        var deleteStreamLink = (this.isPermitted(permissions, ['streams:edit:'+stream.id]) ? <a className="btn btn-danger" onClick={this._handleDelete}>
-            <i className="fa fa-trash"></i>
-        </a> : null);
+        var toggleStreamLink = null;
+        if (this.isPermitted(permissions, ["streams:changestate:" + stream.id])) {
+            if (stream.disabled) {
+                toggleStreamLink = (<a className="btn btn-success toggle-stream-button" onClick={this._onResume}>Start stream</a>);
+            } else {
+                toggleStreamLink = (<a className="btn btn-primary toggle-stream-button" onClick={this._onPause}>Pause stream</a>);
+            }
+        }
 
         var createdFromContentPack = (stream.content_pack ? <i className="fa fa-cube" title="Created from content pack"></i> : null);
 
@@ -77,11 +79,11 @@ var Stream = React.createClass({
                         {editRulesLink}{' '}
                         {manageOutputsLink}{' '}
                         {manageAlertsLink}{' '}
-                        {deleteStreamLink}{' '}
+                        {toggleStreamLink}{' '}
 
                         <StreamControls stream={stream} permissions={this.props.permissions} user={this.props.user}
-                                        onResume={this._onResume} onUpdate={this._onUpdate}
-                                        onPause={this._onPause} onClone={this._onClone} onQuickAdd={this._onQuickAdd}/>
+                                        onDelete={this._onDelete} onUpdate={this._onUpdate} onClone={this._onClone}
+                                        onQuickAdd={this._onQuickAdd}/>
                     </div>
                     <div className="stream-description">
                         {createdFromContentPack}

--- a/javascript/src/components/streams/StreamControls.jsx
+++ b/javascript/src/components/streams/StreamControls.jsx
@@ -14,12 +14,8 @@ var StreamControls = React.createClass({
     getInitialState() {
         return {};
     },
-    _onResume(evt) {
-        this.props.onResume(this.props.stream);
-        this.refs.dropdownButton.setDropdownState(false);
-    },
-    _onPause(evt) {
-        this.props.onPause(this.props.stream);
+    _onDelete(evt) {
+        this.props.onDelete(this.props.stream);
         this.refs.dropdownButton.setDropdownState(false);
     },
     _onEdit(evt) {
@@ -45,14 +41,6 @@ var StreamControls = React.createClass({
             menuItems.push(<MenuItem key={"quickAddRule-" + stream.id} onClick={this._onQuickAdd}>Quick add rule</MenuItem>);
         }
 
-        if (this.isPermitted(permissions, ["streams:changestate:" + stream.id])) {
-            if (stream.disabled) {
-                menuItems.push(<MenuItem key={"startStream-" + stream.id} onClick={this._onResume}>Start this stream</MenuItem>);
-            } else {
-                menuItems.push(<MenuItem key={"stopStream-" + stream.id} onClick={this._onPause}>Stop this stream</MenuItem>);
-            }
-        }
-
         if (this.isPermitted(permissions, ["streams:create", "streams:read:" + stream.id])) {
             menuItems.push(<MenuItem key={"cloneStream-" + stream.id} onClick={this._onClone}>Clone this stream</MenuItem>);
         }
@@ -62,6 +50,11 @@ var StreamControls = React.createClass({
                                      href={this.props.user.readonly ? null : jsRoutes.controllers.StartpageController.set("stream", stream.id).url}>
                 Set as startpage
             </MenuItem>);
+        }
+
+        if (this.isPermitted(permissions, ['streams:edit:' + stream.id])) {
+            menuItems.push(<MenuItem key={'divider-' + stream.id} divider />);
+            menuItems.push(<MenuItem key={'deleteStream-' + stream.id} onClick={this._onDelete}>Delete this stream</MenuItem>);
         }
 
         return (


### PR DESCRIPTION
- Move the stream deletion button into the drop-down menu.
- Put the stream start/pause buttons outside of the drop-down menu.

Changed from this:
![ddhaw9bejrfxubkpk9hsw9m7bag8ukcbk6vx0s2xbrusy42xb34mjz9st12y3vihlpnxstan8fk9vvby8hvzdwqiecbagaabagqiecbagaabagqiecbwkjcwsskunfosvnqqsxw6alsculswboz8lxnazh5lapaemgnfzfkwgheffaecbagqiecaaaecbagqiecaaaecbahctmbru7fspzazl70vwrovl3sgn3q7gqqvcv1mujktxzp40x](https://cloud.githubusercontent.com/assets/461/7705753/743bdb9e-fe46-11e4-8a6d-de35fdbe415c.png)

To this:

![wdi6lnyte1lugaaaabjru5erkjggg](https://cloud.githubusercontent.com/assets/461/7705661/dc8f30ac-fe45-11e4-909c-1b9b2c1b2311.png)