### PR TITLE
some setups have problems with websockets and even xhr_streaming

### DIFF
--- a/app/controllers/api/MetricsController.java
+++ b/app/controllers/api/MetricsController.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import controllers.AuthenticatedController;
+import lib.SockJSUtils;
 import lib.security.RedirectAuthenticator;
 import lib.sockjs.SockJsRouter;
 import models.sockjs.CreateSessionCommand;
@@ -177,7 +178,7 @@ public class MetricsController extends AuthenticatedController {
 
                 @Override
                 public boolean websocket() {
-                    return Boolean.valueOf(System.getProperty("websockets.enabled", "true"));
+                    return Boolean.valueOf(SockJSUtils.isWebsocketsEnabled());
                 }
 
                 @Override

--- a/app/lib/SockJSController.java
+++ b/app/lib/SockJSController.java
@@ -1,6 +1,0 @@
-package lib;
-
-import controllers.AuthenticatedController;
-
-public abstract class SockJSController extends AuthenticatedController {
-}

--- a/app/lib/SockJSUtils.java
+++ b/app/lib/SockJSUtils.java
@@ -1,0 +1,9 @@
+package lib;
+
+public class SockJSUtils {
+    private SockJSUtils() {}
+
+    public static String isWebsocketsEnabled() {
+        return System.getProperty("websockets.enabled", "false");
+    }
+}

--- a/app/views/partials/navbar.scala.html
+++ b/app/views/partials/navbar.scala.html
@@ -14,6 +14,7 @@ gl2AppPathPrefix = "@Configuration.getApplicationContext";
 gl2UserTimeZone = "@DateTools.getUserTimeZone(currentUser)";
 gl2UserTimeZoneOffset = @DateTools.getUserTimeZoneOffset(currentUser);
 gl2UserSessionId = "@Http.Context.current().session().get("sessionid")";
+sockJsWebSocketsEnabled = @lib.SockJSUtils.isWebsocketsEnabled;
 </script>
 
 @helper.javascriptRouter("jsRoutes")(

--- a/javascript/src/stores/metrics/MetricsStore.ts
+++ b/javascript/src/stores/metrics/MetricsStore.ts
@@ -6,6 +6,7 @@
 
 // this is global in top.scala.html
 declare var gl2UserSessionId: string;
+declare var sockJsWebSocketsEnabled: boolean;
 
 var SockJS = require("sockjs-client");
 import UserNotification = require("../../util/UserNotification");
@@ -57,7 +58,14 @@ class MetricsStore {
     private queuedRequests: Array<ListenRequest> = [];
 
     connect() {
-        this.sock = new SockJS(this.METRICS_SOCKJS_URL);
+        if (sockJsWebSocketsEnabled) {
+            this.sock = new SockJS(this.METRICS_SOCKJS_URL);
+        } else {
+            // only allow a subset of transport types.
+            this.sock = new SockJS(this.METRICS_SOCKJS_URL,
+                null, /* reserved param */
+                { transports: ['xhr-polling', 'xdr-polling', 'iframe-xhr-polling', 'jsonp-polling']});
+        }
 
         this.sock.onopen = () => {
             this.isOpen = true;


### PR DESCRIPTION
this changes the default behavior to use xhr-polling (or even more basic polling techniques), while still allowing to use the websockets.enabled sytem property to turn on support for more permissive environments

the default behavior should now properly use plain xhr requests (or xdr on IE 9), and fall back to jsonp or even iframe polling.

fixes #1344, fixes #1353, refs #1338 #1322
