### PR TITLE
Fix NPE in SearchController :hankey:

### DIFF
--- a/app/controllers/SearchController.java
+++ b/app/controllers/SearchController.java
@@ -221,19 +221,23 @@ public class SearchController extends AuthenticatedController {
             // resolve all used inputs and nodes from the result set
             final Map<String, Node> nodeMap = serverNodes.asMap();
             for (final String nodeId : usedInputIds.keySet()) {
-                final HashSet<Input> allInputs = Sets.newHashSet(nodeMap.get(nodeId).getInputs());
-                inputs = Sets.newHashSet(Collections2.transform(Sets.filter(allInputs, new Predicate<Input>() {
-                    @Override
-                    public boolean apply(Input input) {
-                        return usedInputIds.get(nodeId).contains(input.getId());
-                    }
-                }), new Function<Input, InputDescription>() {
-                    @Nullable
-                    @Override
-                    public InputDescription apply(Input input) {
-                        return new InputDescription(input);
-                    }
-                }));
+                final Node node = nodeMap.get(nodeId);
+                if(node != null) {
+                    final HashSet<Input> allInputs = Sets.newHashSet(node.getInputs());
+                    inputs = Sets.newHashSet(Collections2.transform(Sets.filter(allInputs, new Predicate<Input>() {
+                        @Override
+                        public boolean apply(Input input) {
+                            final Set<String> inputIds = usedInputIds.get(nodeId);
+                            return inputIds != null && inputIds.contains(input.getId());
+                        }
+                    }), new Function<Input, InputDescription>() {
+                        @Nullable
+                        @Override
+                        public InputDescription apply(Input input) {
+                            return new InputDescription(input);
+                        }
+                    }));
+                }
             }
 
             // resolve radio inputs


### PR DESCRIPTION
If a message was received on an input which belongs to a non-existing (e. g. decomissioned or simply shutdown) node, retrieving the node information failed miserably with a NullPointerException.

Bonus GIF: http://media.giphy.com/media/AIu96N68WdxGo/giphy.gif

Fixes Graylog2/graylog2-server#1212