### PR TITLE
Improve multi-line log messages support

### DIFF
--- a/app/assets/stylesheets/graylog2.less
+++ b/app/assets/stylesheets/graylog2.less
@@ -2918,6 +2918,26 @@ table.messages tr.message-row {
   cursor: pointer;
 }
 
+table.messages tr.message-row .message-wrapper {
+  line-height: 1.5em;
+  text-indent: -2em; /* As we remove extra empty spaces with pre-line, we want to make clear that this is the first line */
+  padding-left: 2em;
+  white-space: pre-line;
+  max-height: 6em; /* show 4 lines: line-height * 4 */
+  overflow: hidden;
+}
+
+table.messages tr.message-row .message-wrapper:after {
+  content: "";
+  text-align: right;
+  position: absolute;
+  left: 13px;
+  width: 99%;
+  top: 4.5em;
+  height: 1.5em;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 95%);
+}
+
 table.messages tr.message-detail-row {
   display: none;
 }
@@ -2925,6 +2945,11 @@ table.messages tr.message-detail-row {
 table.messages tr.message-detail-row td {
   padding-top: 5px;
   border-top: 0;
+}
+
+table.messages dl.message-details {
+  max-height: 800px;
+  overflow: auto;
 }
 
 dl.message-details {
@@ -2945,6 +2970,15 @@ dl.message-details dd {
 
 dl.message-details-fields dd:not(:last-child) {
   border-bottom: 1px solid #ececec;
+}
+
+dl.message-details-fields dd {
+  white-space: pre-wrap;
+}
+
+dl.message-details-fields dd.message-field .field-value {
+  max-height: 500px;
+  overflow: auto;
 }
 
 dl.message-details dd.stream-list ul {

--- a/javascript/src/components/search/MessageFieldDescription.jsx
+++ b/javascript/src/components/search/MessageFieldDescription.jsx
@@ -69,10 +69,12 @@ var MessageFieldDescription = React.createClass({
             </SplitButton>
         </div>);
 
+        var className = this.props.fieldName === 'message' || this.props.fieldName === 'full_message' ? 'message-field' : '';
+
         return (
-            <dd key={this.props.fieldName + "dd"}>
+            <dd className={className} key={this.props.fieldName + "dd"}>
                 {fieldActions}
-                {this.props.possiblyHighlight(this.props.fieldName)}
+                <div className="field-value">{this.props.possiblyHighlight(this.props.fieldName)}</div>
                 {this._shouldShowTerms() && <br />}
                 {this._shouldShowTerms() && <Alert bsStyle='info' onDismiss={() => this.setState({messageTerms: Immutable.Map()})}>Field terms: {this._getFormattedTerms()}</Alert>}
             </dd>

--- a/javascript/src/components/search/MessageTableEntry.jsx
+++ b/javascript/src/components/search/MessageTableEntry.jsx
@@ -90,7 +90,7 @@ var MessageTableEntry = React.createClass({
 
             {this.props.showMessageRow &&
             <tr className="message-row" onClick={this._toggleDetail}>
-                <td colSpan={colSpanFixup}>{this.possiblyHighlight('message')}</td>
+                <td colSpan={colSpanFixup}><div className="message-wrapper">{this.possiblyHighlight('message')}</div></td>
             </tr>
             }
             {this.props.expanded &&


### PR DESCRIPTION
In order to improve how the new UI is displaying multiline messages (see #612) I did these changes:

On the search result table:
- Keep original line breaks on the search result table, but removing
  extra spaces that might be in there accidentally
- Only display up to 4 lines of the log message, showing a small
  gradient over the last line to indicate that the message continues

On the message details:
- Keep line-breaks and spaces on all fields
- Set a maximum height on message and full_message fields and overflow
  automatically if there is more text

How do you feel about this?