### PR TITLE
Checking for absence of type def to unbreak alarm callback listing.

### DIFF
--- a/javascript/src/components/alarmcallbacks/AlarmCallback.jsx
+++ b/javascript/src/components/alarmcallbacks/AlarmCallback.jsx
@@ -5,41 +5,53 @@ var PermissionsMixin = require('../../util/PermissionsMixin');
 var DeleteAlarmCallbackButton = require('./DeleteAlarmCallbackButton');
 var ConfigurationWell = require('../configurationforms/ConfigurationWell');
 var EditAlarmCallbackButton = require('./EditAlarmCallbackButton');
+var Row = require('react-bootstrap').Row;
+var Col = require('react-bootstrap').Col;
+var Alert = require('react-bootstrap').Alert;
 
 var AlarmCallback = React.createClass({
     mixins: [PermissionsMixin],
+    /* jshint -W116 */
+    _typeNotAvailable() {
+        return (this.props.types[this.props.alarmCallback.type] == undefined);
+    },
     render() {
         var alarmCallback = this.props.alarmCallback;
-        var humanReadableType = this.props.types[alarmCallback.type].name;
+        var humanReadableType = (this._typeNotAvailable() ? <i>Unknown alarm callback</i> : this.props.types[alarmCallback.type].name);
         var editAlarmCallbackButton = (this.isPermitted(this.props.permissions, ["streams:edit:"+this.props.streamId]) ?
-            <EditAlarmCallbackButton alarmCallback={alarmCallback} types={this.props.types} streamId={this.props.streamId} onUpdate={this.props.updateAlarmCallback} /> : "");
+            <EditAlarmCallbackButton disabled={this._typeNotAvailable()} alarmCallback={alarmCallback} types={this.props.types}
+                                     streamId={this.props.streamId} onUpdate={this.props.updateAlarmCallback} /> : null);
         var deleteAlarmCallbackButton = (this.isPermitted(this.props.permissions, ["streams:edit:"+this.props.streamId]) ?
-            <DeleteAlarmCallbackButton alarmCallback={alarmCallback} onClick={this.props.deleteAlarmCallback} /> : "");
+            <DeleteAlarmCallbackButton alarmCallback={alarmCallback} onClick={this.props.deleteAlarmCallback} /> : null);
+        var alert = (this._typeNotAvailable() ? <Alert bsStyle="danger">
+                The plugin required for this alarm callback is not loaded. Editing it is not possible. Please load the plugin or delete the alarm callback.
+            </Alert> : null);
         return (
             <div className="alert-callback" data-destination-id={alarmCallback.id}>
-                <div className="row" style={{marginBottom: 0}}>
-                    <div className="col-md-9">
+                <Row style={{marginBottom: 0}}>
+                    <Col md={9}>
                         <h3>
                             {' '}
                             <span>{humanReadableType}</span>
                         </h3>
 
                         Executed once per triggered alert condition.
-                    </div>
+                    </Col>
 
-                    <div className="col-md-3" style={{textAlign: "right"}}>
+                    <Col md={3} style={{textAlign: "right"}}>
                         {' '}
                         {editAlarmCallbackButton}
                         {' '}
                         {deleteAlarmCallbackButton}
-                    </div>
-                </div>
+                    </Col>
+                </Row>
 
-                <div className="row" style={{marginBottom: 0}}>
-                    <div className="col-md-12">
+                <Row style={{marginBottom: 0}}>
+                    <Col md={12}>
+                        {alert}
                         <ConfigurationWell configuration={alarmCallback.configuration}/>
-                    </div>
-                </div>
+                    </Col>
+                </Row>
 
                 <hr />
             </div>

--- a/javascript/src/components/alarmcallbacks/EditAlarmCallbackButton.jsx
+++ b/javascript/src/components/alarmcallbacks/EditAlarmCallbackButton.jsx
@@ -2,6 +2,7 @@
 
 var React = require('react/addons');
 var ConfigurationForm = require('../configurationforms/ConfigurationForm');
+var Button = require('react-bootstrap').Button;
 
 var EditAlarmCallbackButton = React.createClass({
     _handleClick() {
@@ -10,20 +11,26 @@ var EditAlarmCallbackButton = React.createClass({
     _handleSubmit(data) {
         this.props.onUpdate(this.props.alarmCallback, data);
     },
+    getDefaultProps() {
+        return {
+            disabled: false
+        };
+    },
     render() {
         var alarmCallback = this.props.alarmCallback;
         var definition = this.props.types[alarmCallback.type];
+        var configurationForm = (definition ? <ConfigurationForm ref="configurationForm" key={"configuration-form-alarm-callback-"+alarmCallback.id}
+                                                                 configFields={definition.requested_configuration}
+                                                                 title={"Editing Alarm Callback "}
+                                                                 typeName={alarmCallback.type} includeTitleField={false}
+                                                                 submitAction={this._handleSubmit} values={alarmCallback.configuration} /> : null);
 
         return (
             <span>
-                <button className="btn btn-success" onClick={this._handleClick}>
+                <Button bsStyle="success" disabled={this.props.disabled} onClick={this._handleClick}>
                     Edit callback
-                </button>
-                <ConfigurationForm ref="configurationForm" key={"configuration-form-alarm-callback-"+alarmCallback.id}
-                                   configFields={definition.requested_configuration}
-                                   title={"Editing Alarm Callback "}
-                                   typeName={alarmCallback.type} includeTitleField={false}
-                                   submitAction={this._handleSubmit} values={alarmCallback.configuration} />
+                </Button>
+                {configurationForm}
             </span>
         );
     }


### PR DESCRIPTION
Disabling edit button and show alert if type definition for alarm
callback is not present (mostly because of unloaded plugin providing
the alarm callback).

Fixes #1450