### PR TITLE
allow users with stream edit permissions to pause/resume streams

### DIFF
--- a/javascript/src/components/streams/Stream.jsx
+++ b/javascript/src/components/streams/Stream.jsx
@@ -58,7 +58,7 @@ var Stream = React.createClass({
         }
 
         var toggleStreamLink = null;
-        if (this.isPermitted(permissions, ["streams:changestate:" + stream.id])) {
+        if (this.isAnyPermitted(permissions, ["streams:changestate:" + stream.id, "streams:edit:" + stream.id])) {
             if (stream.disabled) {
                 toggleStreamLink = (<a className="btn btn-success toggle-stream-button" onClick={this._onResume}>Start stream</a>);
             } else {

--- a/javascript/src/util/PermissionsMixin.jsx
+++ b/javascript/src/util/PermissionsMixin.jsx
@@ -1,17 +1,31 @@
 'use strict';
 
 var PermissionsMixin = {
+    _isWildCard: function(permissionSet) {
+        return (permissionSet.indexOf("*") > -1);
+    },
+
+    _permissionPredicate: function(permissionSet, p) {
+        if (p.split(":").length === 3) {
+            return (permissionSet.indexOf(p) > -1) || (permissionSet.indexOf(p.split(":").slice(0,2).join(":") + ":*") > -1);
+        } else {
+            return (permissionSet.indexOf(p) > -1) || (permissionSet.indexOf(p + ":*") > -1);
+        }
+    },
+
     isPermitted: function(permissionSet, permissions) {
-        if (permissionSet.indexOf("*") > -1) {
+        if (this._isWildCard(permissionSet)) {
             return true;
         }
-        var result = permissions.every((p) => {
-                if (p.split(":").length === 3) {
-                    return (permissionSet.indexOf(p) > -1) || (permissionSet.indexOf(p.split(":").slice(0,2).join(":") + ":*") > -1);
-                } else {
-                    return (permissionSet.indexOf(p) > -1) || (permissionSet.indexOf(p + ":*") > -1);
-                }
-            }
+        var result = permissions.every((p) => this._permissionPredicate(permissionSet, p));
+        return result;
+    },
+
+    isAnyPermitted: function(permissionSet, permissions) {
+        if (this._isWildCard(permissionSet)) {
+            return true;
+        }
+        var result = permissions.some((p) => this._permissionPredicate(permissionSet, p)
         );
         return result;
     }


### PR DESCRIPTION
this extends the check from the 'streams:changestate' permission to allow users with 'streams:edit' to perform the same operation.

 fixes #1456
