### PR TITLE
Show Newlines in Log Messages

### DIFF
--- a/app/assets/stylesheets/graylog2.less
+++ b/app/assets/stylesheets/graylog2.less
@@ -2966,6 +2966,10 @@ dl.message-details dd {
   margin-left: 1px; /* Ensures that italic text is not cut */
 }
 
+dl.message-details dd > span {
+  white-space: pre-line;
+}
+
 dl.message-details-fields dd:not(:last-child) {
   border-bottom: 1px solid #ececec;
 }


### PR DESCRIPTION
In the latest interface newlines in log messages aren't displayed. This updates the style to
display them.