### PR TITLE
Fix small header crash in search results

### DIFF
--- a/app/assets/stylesheets/graylog2.less
+++ b/app/assets/stylesheets/graylog2.less
@@ -411,6 +411,7 @@ a.fields-set-chooser {
   font-size: 11px;
   font-weight: normal;
   background-color: #222;
+  white-space: nowrap;
 }
 
 #result-graph-container {


### PR DESCRIPTION
Problem:
![image](https://cloud.githubusercontent.com/assets/741117/8209593/0d12d4fc-150e-11e5-8598-f4794ddb588f.png)
