### PR TITLE
Fix json serialization

### DIFF
--- a/app/controllers/ExtractorsController.java
+++ b/app/controllers/ExtractorsController.java
@@ -23,7 +23,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import lib.BreadcrumbList;
+import lib.json.Json;
 import lib.security.RestPermissions;
+import org.graylog2.rest.models.system.inputs.extractors.requests.CreateExtractorRequest;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
 import org.graylog2.restclient.lib.Version;
@@ -33,12 +35,10 @@ import org.graylog2.restclient.models.Input;
 import org.graylog2.restclient.models.MessagesService;
 import org.graylog2.restclient.models.Node;
 import org.graylog2.restclient.models.NodeService;
-import org.graylog2.rest.models.system.inputs.extractors.requests.CreateExtractorRequest;
 import org.graylog2.restclient.models.api.requests.ExtractorImportRequest;
 import org.graylog2.restclient.models.api.requests.ExtractorListImportRequest;
 import org.graylog2.restclient.models.api.results.MessageResult;
 import play.Logger;
-import play.libs.Json;
 import play.mvc.Result;
 import views.helpers.Permissions;
 
@@ -271,7 +271,7 @@ public class ExtractorsController extends AuthenticatedController {
             result.put("extractors", extractors);
             result.put("version", Version.VERSION.toString());
 
-            String extractorExport = Json.stringify(Json.toJson(result));
+            String extractorExport = Json.toJsonString(result);
 
             return ok(views.html.system.inputs.extractors.export.render(
                             currentUser(),

--- a/app/controllers/LdapController.java
+++ b/app/controllers/LdapController.java
@@ -19,6 +19,7 @@
 package controllers;
 
 import lib.BreadcrumbList;
+import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.accounts.LdapSettings;
 import org.graylog2.restclient.models.accounts.LdapSettingsService;
@@ -29,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.data.DynamicForm;
 import play.data.Form;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -82,7 +82,7 @@ public class LdapController extends AuthenticatedController {
             log.error("Unable to connect", e);
             return internalServerError();
         }
-        return ok(Json.toJson(result));
+        return ok(Json.toJsonString(result)).as("application/json");
     }
 
     public Result apiTestLdapLogin() {
@@ -109,7 +109,7 @@ public class LdapController extends AuthenticatedController {
             log.error("Unable to connect", e);
             return internalServerError();
         }
-        return ok(Json.toJson(result));
+        return ok(Json.toJsonString(result)).as("application/json");
     }
 
     private LdapTestConnectionRequest getLdapTestConnectionRequest(Map<String, String> formData) {

--- a/app/controllers/LdapController.java
+++ b/app/controllers/LdapController.java
@@ -18,6 +18,7 @@
  */
 package controllers;
 
+import com.google.common.net.MediaType;
 import lib.BreadcrumbList;
 import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
@@ -82,7 +83,7 @@ public class LdapController extends AuthenticatedController {
             log.error("Unable to connect", e);
             return internalServerError();
         }
-        return ok(Json.toJsonString(result)).as("application/json");
+        return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result apiTestLdapLogin() {
@@ -109,7 +110,7 @@ public class LdapController extends AuthenticatedController {
             log.error("Unable to connect", e);
             return internalServerError();
         }
-        return ok(Json.toJsonString(result)).as("application/json");
+        return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
     }
 
     private LdapTestConnectionRequest getLdapTestConnectionRequest(Map<String, String> formData) {

--- a/app/controllers/LonesomeInterfaceController.java
+++ b/app/controllers/LonesomeInterfaceController.java
@@ -19,6 +19,7 @@
 package controllers;
 
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import lib.json.Json;
 import org.graylog2.restclient.lib.ServerNodes;
 import org.graylog2.restclient.models.Node;
@@ -52,6 +53,6 @@ public class LonesomeInterfaceController extends BaseController {
         map.put("connected", serverNodes.isConnected());
         map.put("connected_nodes_count", serverNodes.connectedNodesCount());
         map.put("total_nodes_count", serverNodes.totalNodesCount());
-        return ok(Json.toJsonString(map)).as("application/json");
+        return ok(Json.toJsonString(map)).as(MediaType.JSON_UTF_8.toString());
     }
 }

--- a/app/controllers/LonesomeInterfaceController.java
+++ b/app/controllers/LonesomeInterfaceController.java
@@ -19,9 +19,9 @@
 package controllers;
 
 import com.google.common.collect.Maps;
+import lib.json.Json;
 import org.graylog2.restclient.lib.ServerNodes;
 import org.graylog2.restclient.models.Node;
-import play.libs.Json;
 import play.mvc.Http;
 import play.mvc.Result;
 
@@ -52,6 +52,6 @@ public class LonesomeInterfaceController extends BaseController {
         map.put("connected", serverNodes.isConnected());
         map.put("connected_nodes_count", serverNodes.connectedNodesCount());
         map.put("total_nodes_count", serverNodes.totalNodesCount());
-        return ok(Json.toJson(map));
+        return ok(Json.toJsonString(map)).as("application/json");
     }
 }

--- a/app/controllers/MessageCountsController.java
+++ b/app/controllers/MessageCountsController.java
@@ -19,8 +19,8 @@
 package controllers;
 
 import com.google.common.collect.Maps;
+import lib.json.Json;
 import org.graylog2.restclient.models.MessagesService;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -40,6 +40,6 @@ public class MessageCountsController extends AuthenticatedController {
         Map<String, Long> result = Maps.newHashMap();
         result.put("events", countResult);
 
-        return ok(Json.toJson(result));
+        return ok(Json.toJsonString(result)).as("application/json");
     }
 }

--- a/app/controllers/MessageCountsController.java
+++ b/app/controllers/MessageCountsController.java
@@ -19,6 +19,7 @@
 package controllers;
 
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import lib.json.Json;
 import org.graylog2.restclient.models.MessagesService;
 import play.mvc.Result;
@@ -40,6 +41,6 @@ public class MessageCountsController extends AuthenticatedController {
         Map<String, Long> result = Maps.newHashMap();
         result.put("events", countResult);
 
-        return ok(Json.toJsonString(result)).as("application/json");
+        return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
     }
 }

--- a/app/controllers/MessagesController.java
+++ b/app/controllers/MessagesController.java
@@ -19,6 +19,7 @@
 package controllers;
 
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
@@ -52,7 +53,7 @@ public class MessagesController extends AuthenticatedController {
             result.put("fields", message.getFields());
             result.put("formatted_fields", message.getFormattedFields());
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return status(500);
         } catch (APIException e) {
@@ -70,7 +71,7 @@ public class MessagesController extends AuthenticatedController {
             }
             final String stringifiedValue = String.valueOf(analyzeField);
             MessageAnalyzeResult result = messagesService.analyze(index, stringifiedValue);
-            return ok(Json.toJsonString(result.getTokens())).as("application/json");
+            return ok(Json.toJsonString(result.getTokens())).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return status(500, views.html.errors.error.render(ApiClient.ERROR_MSG_IO, e, request()));
         } catch (APIException e) {

--- a/app/controllers/MessagesController.java
+++ b/app/controllers/MessagesController.java
@@ -19,12 +19,12 @@
 package controllers;
 
 import com.google.common.collect.Maps;
+import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
 import org.graylog2.restclient.models.MessagesService;
 import org.graylog2.restclient.models.api.results.MessageAnalyzeResult;
 import org.graylog2.restclient.models.api.results.MessageResult;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -52,7 +52,7 @@ public class MessagesController extends AuthenticatedController {
             result.put("fields", message.getFields());
             result.put("formatted_fields", message.getFormattedFields());
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (IOException e) {
             return status(500);
         } catch (APIException e) {
@@ -70,7 +70,7 @@ public class MessagesController extends AuthenticatedController {
             }
             final String stringifiedValue = String.valueOf(analyzeField);
             MessageAnalyzeResult result = messagesService.analyze(index, stringifiedValue);
-            return ok(Json.toJson(result.getTokens()));
+            return ok(Json.toJsonString(result.getTokens())).as("application/json");
         } catch (IOException e) {
             return status(500, views.html.errors.error.render(ApiClient.ERROR_MSG_IO, e, request()));
         } catch (APIException e) {

--- a/app/controllers/SearchController.java
+++ b/app/controllers/SearchController.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.net.MediaType;
 import lib.SearchTools;
+import lib.json.Json;
 import lib.security.RestPermissions;
 import models.descriptions.InputDescription;
 import models.descriptions.NodeDescription;
@@ -60,7 +61,6 @@ import org.graylog2.restclient.models.api.results.MessageResult;
 import org.graylog2.restclient.models.api.results.SearchResult;
 import org.joda.time.Minutes;
 import play.Logger;
-import play.libs.Json;
 import play.mvc.Result;
 import views.helpers.Permissions;
 
@@ -395,7 +395,7 @@ public class SearchController extends AuthenticatedController {
             index++;
         }
 
-        return Json.stringify(Json.toJson(points));
+        return Json.toJsonString(points);
     }
 
     protected Set<String> getSelectedFields(String fields) {

--- a/app/controllers/api/AlarmCallbacksApiController.java
+++ b/app/controllers/api/AlarmCallbacksApiController.java
@@ -1,6 +1,7 @@
 package controllers.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import lib.security.RestPermissions;
@@ -29,13 +30,13 @@ public class AlarmCallbacksApiController extends AuthenticatedController {
     public Result available(String streamId) throws IOException, APIException {
         Map<String, AvailableAlarmCallbackSummaryResponse> availableAlarmCallbacks = alarmCallbackService.available(streamId);
 
-        return ok(Json.toJsonString(availableAlarmCallbacks)).as("application/json");
+        return ok(Json.toJsonString(availableAlarmCallbacks)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result list(String streamId) throws IOException, APIException {
         final List<AlarmCallback> alarmCallbacks = this.alarmCallbackService.all(streamId);
 
-        return ok(Json.toJsonString(alarmCallbacks)).as("application/json");
+        return ok(Json.toJsonString(alarmCallbacks)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result create(String streamId) throws IOException, APIException {
@@ -45,7 +46,7 @@ public class AlarmCallbacksApiController extends AuthenticatedController {
         final JsonNode json = request().body().asJson();
         final CreateAlarmCallbackRequest request = Json.fromJson(json, CreateAlarmCallbackRequest.class);
 
-        return ok(Json.toJsonString(alarmCallbackService.create(streamId, request))).as("application/json");
+        return ok(Json.toJsonString(alarmCallbackService.create(streamId, request))).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result delete(String streamId, String alarmCallbackId) throws IOException, APIException {

--- a/app/controllers/api/AlarmCallbacksApiController.java
+++ b/app/controllers/api/AlarmCallbacksApiController.java
@@ -2,13 +2,13 @@ package controllers.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import lib.security.RestPermissions;
 import org.graylog2.rest.models.alarmcallbacks.responses.AvailableAlarmCallbackSummaryResponse;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.AlarmCallback;
 import org.graylog2.restclient.models.AlarmCallbackService;
 import org.graylog2.restclient.models.api.requests.alarmcallbacks.CreateAlarmCallbackRequest;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -29,13 +29,13 @@ public class AlarmCallbacksApiController extends AuthenticatedController {
     public Result available(String streamId) throws IOException, APIException {
         Map<String, AvailableAlarmCallbackSummaryResponse> availableAlarmCallbacks = alarmCallbackService.available(streamId);
 
-        return ok(Json.toJson(availableAlarmCallbacks));
+        return ok(Json.toJsonString(availableAlarmCallbacks)).as("application/json");
     }
 
     public Result list(String streamId) throws IOException, APIException {
         final List<AlarmCallback> alarmCallbacks = this.alarmCallbackService.all(streamId);
 
-        return ok(Json.toJson(alarmCallbacks));
+        return ok(Json.toJsonString(alarmCallbacks)).as("application/json");
     }
 
     public Result create(String streamId) throws IOException, APIException {
@@ -45,7 +45,7 @@ public class AlarmCallbacksApiController extends AuthenticatedController {
         final JsonNode json = request().body().asJson();
         final CreateAlarmCallbackRequest request = Json.fromJson(json, CreateAlarmCallbackRequest.class);
 
-        return ok(Json.toJson(alarmCallbackService.create(streamId, request)));
+        return ok(Json.toJsonString(alarmCallbackService.create(streamId, request))).as("application/json");
     }
 
     public Result delete(String streamId, String alarmCallbackId) throws IOException, APIException {

--- a/app/controllers/api/AlertsApiController.java
+++ b/app/controllers/api/AlertsApiController.java
@@ -22,11 +22,11 @@ package controllers.api;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.Stream;
 import org.graylog2.restclient.models.StreamService;
 import org.graylog2.restclient.models.alerts.Alert;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -65,7 +65,7 @@ public class AlertsApiController extends AuthenticatedController {
 
             result.put("alerts", alerts);
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/controllers/api/AlertsApiController.java
+++ b/app/controllers/api/AlertsApiController.java
@@ -21,6 +21,7 @@ package controllers.api;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
@@ -65,7 +66,7 @@ public class AlertsApiController extends AuthenticatedController {
 
             result.put("alerts", alerts);
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/controllers/api/BundlesApiController.java
+++ b/app/controllers/api/BundlesApiController.java
@@ -18,22 +18,19 @@ package controllers.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Multimap;
-import com.google.common.io.Files;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import org.graylog2.restclient.models.api.requests.CreateBundleRequest;
 import org.graylog2.restclient.models.bundles.BundleService;
 import org.graylog2.restclient.models.bundles.ConfigurationBundle;
 import play.Logger;
-import play.libs.Json;
 import play.mvc.BodyParser;
 import play.mvc.Http.MultipartFormData;
 import play.mvc.Http.MultipartFormData.FilePart;
 import play.mvc.Result;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 public class BundlesApiController extends AuthenticatedController {
     private final BundleService bundleService;
@@ -48,7 +45,7 @@ public class BundlesApiController extends AuthenticatedController {
     public Result index() {
         Multimap<String, ConfigurationBundle> bundles = bundleService.all();
 
-        return ok(Json.toJson(bundles.asMap()));
+        return ok(Json.toJsonString(bundles.asMap())).as("application/json");
     }
 
     @BodyParser.Of(BodyParser.MultipartFormData.class)

--- a/app/controllers/api/BundlesApiController.java
+++ b/app/controllers/api/BundlesApiController.java
@@ -18,6 +18,7 @@ package controllers.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Multimap;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import org.graylog2.restclient.models.api.requests.CreateBundleRequest;
@@ -45,7 +46,7 @@ public class BundlesApiController extends AuthenticatedController {
     public Result index() {
         Multimap<String, ConfigurationBundle> bundles = bundleService.all();
 
-        return ok(Json.toJsonString(bundles.asMap())).as("application/json");
+        return ok(Json.toJsonString(bundles.asMap())).as(MediaType.JSON_UTF_8.toString());
     }
 
     @BodyParser.Of(BodyParser.MultipartFormData.class)

--- a/app/controllers/api/CollectorsApiController.java
+++ b/app/controllers/api/CollectorsApiController.java
@@ -1,10 +1,10 @@
 package controllers.api;
 
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import org.graylog2.rest.models.collector.responses.CollectorSummary;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.CollectorService;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -22,6 +22,6 @@ public class CollectorsApiController extends AuthenticatedController {
     public Result index() throws APIException, IOException {
         final List<CollectorSummary> collectors = collectorService.all();
 
-        return ok(Json.toJson(collectors));
+        return ok(Json.toJsonString(collectors)).as("application/json");
     }
 }

--- a/app/controllers/api/CollectorsApiController.java
+++ b/app/controllers/api/CollectorsApiController.java
@@ -1,5 +1,6 @@
 package controllers.api;
 
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import org.graylog2.rest.models.collector.responses.CollectorSummary;
@@ -22,6 +23,6 @@ public class CollectorsApiController extends AuthenticatedController {
     public Result index() throws APIException, IOException {
         final List<CollectorSummary> collectors = collectorService.all();
 
-        return ok(Json.toJsonString(collectors)).as("application/json");
+        return ok(Json.toJsonString(collectors)).as(MediaType.JSON_UTF_8.toString());
     }
 }

--- a/app/controllers/api/DashboardsApiController.java
+++ b/app/controllers/api/DashboardsApiController.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import lib.security.RestPermissions;
 import org.graylog2.rest.models.dashboards.requests.AddWidgetRequest;
 import org.graylog2.restclient.lib.APIException;
@@ -53,7 +54,6 @@ import org.joda.time.Minutes;
 import org.joda.time.MutableDateTime;
 import org.joda.time.Weeks;
 import play.Logger;
-import play.libs.Json;
 import play.mvc.BodyParser;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -87,7 +87,7 @@ public class DashboardsApiController extends AuthenticatedController {
                 result.put(d.getId(), dashboard);
             }
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (APIException e) {
             String message = "Could not get dashboards. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));
@@ -109,7 +109,7 @@ public class DashboardsApiController extends AuthenticatedController {
                 result.put(d.getId(), dashboard);
             }
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (APIException e) {
             String message = "Could not get dashboards. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));
@@ -143,7 +143,7 @@ public class DashboardsApiController extends AuthenticatedController {
         try {
             final String dashboardId = dashboardService.create(cdr);
 
-            return ok(Json.toJson(dashboardId));
+            return ok(Json.toJsonString(dashboardId)).as("application/json");
         } catch (APIException e) {
             String message = "Could not create dashboard. We expected HTTP 201, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));
@@ -208,7 +208,7 @@ public class DashboardsApiController extends AuthenticatedController {
             result.put("creator_user_id", widget.getCreatorUserId());
             result.put("config", widget.getConfig());
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (APIException e) {
             String message = "Could not get dashboard. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));
@@ -239,7 +239,7 @@ public class DashboardsApiController extends AuthenticatedController {
             result.put("calculated_at", widgetValue.calculatedAt);
             result.put("time_range", widgetValue.computationTimeRange);
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (APIException e) {
             String message = "Could not get dashboard. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));

--- a/app/controllers/api/DashboardsApiController.java
+++ b/app/controllers/api/DashboardsApiController.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import lib.security.RestPermissions;
@@ -87,7 +88,7 @@ public class DashboardsApiController extends AuthenticatedController {
                 result.put(d.getId(), dashboard);
             }
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (APIException e) {
             String message = "Could not get dashboards. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));
@@ -109,7 +110,7 @@ public class DashboardsApiController extends AuthenticatedController {
                 result.put(d.getId(), dashboard);
             }
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (APIException e) {
             String message = "Could not get dashboards. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));
@@ -143,7 +144,7 @@ public class DashboardsApiController extends AuthenticatedController {
         try {
             final String dashboardId = dashboardService.create(cdr);
 
-            return ok(Json.toJsonString(dashboardId)).as("application/json");
+            return ok(Json.toJsonString(dashboardId)).as(MediaType.JSON_UTF_8.toString());
         } catch (APIException e) {
             String message = "Could not create dashboard. We expected HTTP 201, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));
@@ -208,7 +209,7 @@ public class DashboardsApiController extends AuthenticatedController {
             result.put("creator_user_id", widget.getCreatorUserId());
             result.put("config", widget.getConfig());
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (APIException e) {
             String message = "Could not get dashboard. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));
@@ -239,7 +240,7 @@ public class DashboardsApiController extends AuthenticatedController {
             result.put("calculated_at", widgetValue.calculatedAt);
             result.put("time_range", widgetValue.computationTimeRange);
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (APIException e) {
             String message = "Could not get dashboard. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));

--- a/app/controllers/api/GrokPatternsApiController.java
+++ b/app/controllers/api/GrokPatternsApiController.java
@@ -20,12 +20,12 @@ package controllers.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import controllers.AuthenticatedController;
+import lib.json.Json;
+import org.graylog2.rest.models.system.responses.GrokPatternSummary;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.ExtractorService;
-import org.graylog2.rest.models.system.responses.GrokPatternSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -43,7 +43,7 @@ public class GrokPatternsApiController extends AuthenticatedController {
 
     public Result index() {
         try {
-            return ok(Json.toJson(extractorService.allGrokPatterns()));
+            return ok(Json.toJsonString(extractorService.allGrokPatterns())).as("application/json");
         } catch (APIException | IOException e) {
             log.error("Unable to get grok patterns");
         }

--- a/app/controllers/api/GrokPatternsApiController.java
+++ b/app/controllers/api/GrokPatternsApiController.java
@@ -19,6 +19,7 @@
 package controllers.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import org.graylog2.rest.models.system.responses.GrokPatternSummary;
@@ -43,7 +44,7 @@ public class GrokPatternsApiController extends AuthenticatedController {
 
     public Result index() {
         try {
-            return ok(Json.toJsonString(extractorService.allGrokPatterns())).as("application/json");
+            return ok(Json.toJsonString(extractorService.allGrokPatterns())).as(MediaType.JSON_UTF_8.toString());
         } catch (APIException | IOException e) {
             log.error("Unable to get grok patterns");
         }

--- a/app/controllers/api/IndicesApiController.java
+++ b/app/controllers/api/IndicesApiController.java
@@ -23,6 +23,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
@@ -74,7 +75,7 @@ public class IndicesApiController extends AuthenticatedController {
             result.put("queryRecordCount", failures.total);
             result.put("totalRecordCount", failures.total);
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (APIException e) {
             String message = "Could not get indexer failures. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));

--- a/app/controllers/api/IndicesApiController.java
+++ b/app/controllers/api/IndicesApiController.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
 import org.graylog2.restclient.lib.DateTools;
@@ -33,7 +34,6 @@ import org.graylog2.restclient.models.IndexService;
 import org.graylog2.restclient.models.api.responses.system.indices.IndexerFailureSummary;
 import org.graylog2.restclient.models.api.responses.system.indices.IndexerFailuresResponse;
 import org.joda.time.DateTime;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.annotation.Nullable;
@@ -74,7 +74,7 @@ public class IndicesApiController extends AuthenticatedController {
             result.put("queryRecordCount", failures.total);
             result.put("totalRecordCount", failures.total);
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (APIException e) {
             String message = "Could not get indexer failures. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, views.html.errors.error.render(message, e, request()));

--- a/app/controllers/api/InputsApiController.java
+++ b/app/controllers/api/InputsApiController.java
@@ -22,6 +22,7 @@ package controllers.api;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import models.descriptions.InputDescription;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
@@ -38,7 +39,6 @@ import org.graylog2.restclient.models.UniversalSearch;
 import org.graylog2.restclient.models.api.results.MessageResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -73,7 +73,7 @@ public class InputsApiController extends AuthenticatedController {
             result.add(new InputDescription(inputState.getInput()));
         }
 
-        return ok(Json.toJson(result));
+        return ok(Json.toJsonString(result)).as("application/json");
     }
 
     public Result io(String nodeId, String inputId) {
@@ -89,7 +89,7 @@ public class InputsApiController extends AuthenticatedController {
             result.put("rx", Tools.byteToHuman(ioStats.readBytes));
             result.put("tx", Tools.byteToHuman(ioStats.writtenBytes));
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -123,7 +123,7 @@ public class InputsApiController extends AuthenticatedController {
         result.put("rx", Tools.byteToHuman(ioStats.readBytes));
         result.put("tx", Tools.byteToHuman(ioStats.writtenBytes));
 
-        return ok(Json.toJson(result));
+        return ok(Json.toJsonString(result)).as("application/json");
     }
 
     public Result connections(String nodeId, String inputId) {
@@ -136,7 +136,7 @@ public class InputsApiController extends AuthenticatedController {
             result.put("active", input.getConnections());
             result.put("total", input.getTotalConnections());
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -153,7 +153,7 @@ public class InputsApiController extends AuthenticatedController {
 
         List<MessageResult> messages = search.search().getMessages();
         if (messages.size() > 0) {
-            return ok(Json.toJson(buildResultFromMessage(messages.get(0))));
+            return ok(Json.toJsonString(buildResultFromMessage(messages.get(0)))).as("application/json");
         } else {
             return notFound();
         }
@@ -168,7 +168,7 @@ public class InputsApiController extends AuthenticatedController {
                 return notFound();
             }
 
-            return ok(Json.toJson(buildResultFromMessage(recentlyReceivedMessage)));
+            return ok(Json.toJsonString(buildResultFromMessage(recentlyReceivedMessage))).as("application/json");
         } catch (IOException e) {
             return status(500);
         } catch (APIException e) {

--- a/app/controllers/api/InputsApiController.java
+++ b/app/controllers/api/InputsApiController.java
@@ -21,6 +21,7 @@ package controllers.api;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import models.descriptions.InputDescription;
@@ -73,7 +74,7 @@ public class InputsApiController extends AuthenticatedController {
             result.add(new InputDescription(inputState.getInput()));
         }
 
-        return ok(Json.toJsonString(result)).as("application/json");
+        return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result io(String nodeId, String inputId) {
@@ -89,7 +90,7 @@ public class InputsApiController extends AuthenticatedController {
             result.put("rx", Tools.byteToHuman(ioStats.readBytes));
             result.put("tx", Tools.byteToHuman(ioStats.writtenBytes));
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -123,7 +124,7 @@ public class InputsApiController extends AuthenticatedController {
         result.put("rx", Tools.byteToHuman(ioStats.readBytes));
         result.put("tx", Tools.byteToHuman(ioStats.writtenBytes));
 
-        return ok(Json.toJsonString(result)).as("application/json");
+        return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result connections(String nodeId, String inputId) {
@@ -136,7 +137,7 @@ public class InputsApiController extends AuthenticatedController {
             result.put("active", input.getConnections());
             result.put("total", input.getTotalConnections());
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -153,7 +154,7 @@ public class InputsApiController extends AuthenticatedController {
 
         List<MessageResult> messages = search.search().getMessages();
         if (messages.size() > 0) {
-            return ok(Json.toJsonString(buildResultFromMessage(messages.get(0)))).as("application/json");
+            return ok(Json.toJsonString(buildResultFromMessage(messages.get(0)))).as(MediaType.JSON_UTF_8.toString());
         } else {
             return notFound();
         }
@@ -168,7 +169,7 @@ public class InputsApiController extends AuthenticatedController {
                 return notFound();
             }
 
-            return ok(Json.toJsonString(buildResultFromMessage(recentlyReceivedMessage))).as("application/json");
+            return ok(Json.toJsonString(buildResultFromMessage(recentlyReceivedMessage))).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return status(500);
         } catch (APIException e) {

--- a/app/controllers/api/MetricsController.java
+++ b/app/controllers/api/MetricsController.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import controllers.AuthenticatedController;
 import lib.SockJSUtils;
+import lib.json.Json;
 import lib.security.RedirectAuthenticator;
 import lib.sockjs.SockJsRouter;
 import models.sockjs.CreateSessionCommand;
@@ -27,7 +28,6 @@ import org.graylog2.restclient.models.api.responses.metrics.MetricsListResponse;
 import org.slf4j.LoggerFactory;
 import play.Play;
 import play.libs.F;
-import play.libs.Json;
 import play.sockjs.CookieCalculator;
 import play.sockjs.ScriptLocation;
 import play.sockjs.SockJS;
@@ -144,7 +144,7 @@ public class MetricsController extends AuthenticatedController {
                 for (String nodeId : entries.keySet()) {
                     pushResponse.metrics.add(createMetricUpdate(nodeId, entries.get(nodeId)));
                 }
-                out.write(Json.toJson(pushResponse).toString());
+                out.write(Json.toJsonString(pushResponse));
             } catch (Exception e){
                 log.error("Unhandled exception, catching to prevent scheduled task from ending, this is a bug.", e);
             }

--- a/app/controllers/api/NodesApiController.java
+++ b/app/controllers/api/NodesApiController.java
@@ -1,6 +1,7 @@
 package controllers.api;
 
 import com.google.common.collect.Lists;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import models.descriptions.NodeDescription;
@@ -43,6 +44,6 @@ public class NodesApiController extends AuthenticatedController {
             return status(504, message);
         }
 
-        return ok(Json.toJsonString(nodes)).as("application/json");
+        return ok(Json.toJsonString(nodes)).as(MediaType.JSON_UTF_8.toString());
     }
 }

--- a/app/controllers/api/NodesApiController.java
+++ b/app/controllers/api/NodesApiController.java
@@ -2,13 +2,13 @@ package controllers.api;
 
 import com.google.common.collect.Lists;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import models.descriptions.NodeDescription;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ServerNodes;
 import org.graylog2.restclient.models.Node;
 import org.graylog2.restclient.models.NodeService;
 import org.graylog2.restclient.models.Radio;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -43,6 +43,6 @@ public class NodesApiController extends AuthenticatedController {
             return status(504, message);
         }
 
-        return ok(Json.toJson(nodes));
+        return ok(Json.toJsonString(nodes)).as("application/json");
     }
 }

--- a/app/controllers/api/OutputsApiController.java
+++ b/app/controllers/api/OutputsApiController.java
@@ -3,13 +3,13 @@ package controllers.api;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Maps;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import lib.security.RestPermissions;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.Output;
 import org.graylog2.restclient.models.OutputService;
 import org.graylog2.restclient.models.api.requests.outputs.OutputLaunchRequest;
 import org.graylog2.restclient.models.api.responses.AvailableOutputSummary;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -33,14 +33,14 @@ public class OutputsApiController extends AuthenticatedController {
         }
         final List<Output> outputs = outputService.list();
 
-        return ok(Json.toJson(outputs));
+        return ok(Json.toJsonString(outputs)).as("application/json");
     }
 
     public Result available(String outputType) throws APIException, IOException {
         final Map<String, AvailableOutputSummary> types = outputService.available().types;
         final AvailableOutputSummary result = types.get(outputType);
         if (result != null) {
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } else {
             return notFound();
         }
@@ -54,7 +54,7 @@ public class OutputsApiController extends AuthenticatedController {
         for (Map.Entry<String, AvailableOutputSummary> entry : types.entrySet()) {
             result.put(entry.getKey(), entry.getValue().name);
         }
-        return ok(Json.toJson(result));
+        return ok(Json.toJsonString(result)).as("application/json");
     }
 
     public Result delete(String outputId) throws APIException, IOException {
@@ -74,7 +74,7 @@ public class OutputsApiController extends AuthenticatedController {
 
         final Output output = outputService.create(request);
 
-        return ok(Json.toJson(output));
+        return ok(Json.toJsonString(output)).as("application/json");
     }
 
     public Result update(String outputId) throws APIException, IOException {
@@ -86,6 +86,6 @@ public class OutputsApiController extends AuthenticatedController {
 
         final Output output = outputService.update(outputId, request);
 
-        return ok(Json.toJson(output));
+        return ok(Json.toJsonString(output)).as("application/json");
     }
 }

--- a/app/controllers/api/OutputsApiController.java
+++ b/app/controllers/api/OutputsApiController.java
@@ -2,6 +2,7 @@ package controllers.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import lib.security.RestPermissions;
@@ -33,14 +34,14 @@ public class OutputsApiController extends AuthenticatedController {
         }
         final List<Output> outputs = outputService.list();
 
-        return ok(Json.toJsonString(outputs)).as("application/json");
+        return ok(Json.toJsonString(outputs)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result available(String outputType) throws APIException, IOException {
         final Map<String, AvailableOutputSummary> types = outputService.available().types;
         final AvailableOutputSummary result = types.get(outputType);
         if (result != null) {
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } else {
             return notFound();
         }
@@ -54,7 +55,7 @@ public class OutputsApiController extends AuthenticatedController {
         for (Map.Entry<String, AvailableOutputSummary> entry : types.entrySet()) {
             result.put(entry.getKey(), entry.getValue().name);
         }
-        return ok(Json.toJsonString(result)).as("application/json");
+        return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result delete(String outputId) throws APIException, IOException {
@@ -74,7 +75,7 @@ public class OutputsApiController extends AuthenticatedController {
 
         final Output output = outputService.create(request);
 
-        return ok(Json.toJsonString(output)).as("application/json");
+        return ok(Json.toJsonString(output)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result update(String outputId) throws APIException, IOException {
@@ -86,6 +87,6 @@ public class OutputsApiController extends AuthenticatedController {
 
         final Output output = outputService.update(outputId, request);
 
-        return ok(Json.toJsonString(output)).as("application/json");
+        return ok(Json.toJsonString(output)).as(MediaType.JSON_UTF_8.toString());
     }
 }

--- a/app/controllers/api/SavedSearchesApiController.java
+++ b/app/controllers/api/SavedSearchesApiController.java
@@ -22,11 +22,11 @@ package controllers.api;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.SavedSearch;
 import org.graylog2.restclient.models.SavedSearchService;
 import org.graylog2.restclient.models.api.requests.searches.CreateSavedSearchRequest;
-import play.libs.Json;
 import play.mvc.BodyParser;
 import play.mvc.Result;
 
@@ -55,7 +55,7 @@ public class SavedSearchesApiController extends AuthenticatedController {
                 response.add(search);
             }
 
-            return ok(Json.toJson(response));
+            return ok(Json.toJsonString(response)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/controllers/api/SavedSearchesApiController.java
+++ b/app/controllers/api/SavedSearchesApiController.java
@@ -21,6 +21,7 @@ package controllers.api;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
@@ -55,7 +56,7 @@ public class SavedSearchesApiController extends AuthenticatedController {
                 response.add(search);
             }
 
-            return ok(Json.toJsonString(response)).as("application/json");
+            return ok(Json.toJsonString(response)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/controllers/api/SearchApiController.java
+++ b/app/controllers/api/SearchApiController.java
@@ -20,6 +20,7 @@ package controllers.api;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.SearchTools;
 import lib.json.Json;
@@ -90,7 +91,7 @@ public class SearchApiController extends AuthenticatedController {
             result.put("std_deviation", stats.stdDeviation);
             result.put("cardinality", stats.cardinality);
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -134,7 +135,7 @@ public class SearchApiController extends AuthenticatedController {
             result.put("other", terms.other);
             result.put("terms", terms.terms);
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -188,7 +189,7 @@ public class SearchApiController extends AuthenticatedController {
             result.put("from", boundaries.getFrom());
             result.put("to", boundaries.getTo());
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -239,7 +240,7 @@ public class SearchApiController extends AuthenticatedController {
             result.put("from", boundaries.getFrom());
             result.put("to", boundaries.getTo());
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/controllers/api/SearchApiController.java
+++ b/app/controllers/api/SearchApiController.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import controllers.AuthenticatedController;
 import lib.SearchTools;
+import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.timeranges.AbsoluteRange;
 import org.graylog2.restclient.lib.timeranges.InvalidRangeParametersException;
@@ -39,7 +40,6 @@ import org.joda.time.Hours;
 import org.joda.time.Minutes;
 import org.joda.time.MutableDateTime;
 import org.joda.time.Weeks;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -90,7 +90,7 @@ public class SearchApiController extends AuthenticatedController {
             result.put("std_deviation", stats.stdDeviation);
             result.put("cardinality", stats.cardinality);
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -134,7 +134,7 @@ public class SearchApiController extends AuthenticatedController {
             result.put("other", terms.other);
             result.put("terms", terms.terms);
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -188,7 +188,7 @@ public class SearchApiController extends AuthenticatedController {
             result.put("from", boundaries.getFrom());
             result.put("to", boundaries.getTo());
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -239,7 +239,7 @@ public class SearchApiController extends AuthenticatedController {
             result.put("from", boundaries.getFrom());
             result.put("to", boundaries.getTo());
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/controllers/api/SourcesApiController.java
+++ b/app/controllers/api/SourcesApiController.java
@@ -19,6 +19,7 @@
  */
 package controllers.api;
 
+import com.google.common.net.MediaType;
 import com.google.inject.Inject;
 import controllers.AuthenticatedController;
 import lib.json.Json;
@@ -40,7 +41,7 @@ public class SourcesApiController extends AuthenticatedController {
         }
         try {
             List<Source> sources = sourcesService.all(range);
-            return ok(Json.toJsonString(sources)).as("application/json");
+            return ok(Json.toJsonString(sources)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/controllers/api/SourcesApiController.java
+++ b/app/controllers/api/SourcesApiController.java
@@ -21,10 +21,10 @@ package controllers.api;
 
 import com.google.inject.Inject;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.Source;
 import org.graylog2.restclient.models.SourcesService;
-import play.libs.Json;
 import play.mvc.Result;
 
 import java.io.IOException;
@@ -40,7 +40,7 @@ public class SourcesApiController extends AuthenticatedController {
         }
         try {
             List<Source> sources = sourcesService.all(range);
-            return ok(Json.toJson(sources));
+            return ok(Json.toJsonString(sources)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/controllers/api/StreamOutputsApiController.java
+++ b/app/controllers/api/StreamOutputsApiController.java
@@ -1,5 +1,6 @@
 package controllers.api;
 
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import lib.security.RestPermissions;
@@ -24,7 +25,7 @@ public class StreamOutputsApiController extends AuthenticatedController {
         if (!isPermitted(RestPermissions.STREAMS_READ, streamId) || !isPermitted(RestPermissions.OUTPUTS_READ))
             return forbidden();
 
-        return ok(Json.toJsonString(streamService.getOutputs(streamId))).as("application/json");
+        return ok(Json.toJsonString(streamService.getOutputs(streamId))).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result delete(String streamId, String outputId) throws APIException, IOException {

--- a/app/controllers/api/StreamOutputsApiController.java
+++ b/app/controllers/api/StreamOutputsApiController.java
@@ -1,14 +1,13 @@
 package controllers.api;
 
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import lib.security.RestPermissions;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.StreamService;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
-
 import java.io.IOException;
 
 import static views.helpers.Permissions.isPermitted;
@@ -25,7 +24,7 @@ public class StreamOutputsApiController extends AuthenticatedController {
         if (!isPermitted(RestPermissions.STREAMS_READ, streamId) || !isPermitted(RestPermissions.OUTPUTS_READ))
             return forbidden();
 
-        return ok(Json.toJson(streamService.getOutputs(streamId)));
+        return ok(Json.toJsonString(streamService.getOutputs(streamId))).as("application/json");
     }
 
     public Result delete(String streamId, String outputId) throws APIException, IOException {

--- a/app/controllers/api/StreamRulesApiController.java
+++ b/app/controllers/api/StreamRulesApiController.java
@@ -3,13 +3,13 @@ package controllers.api;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.StreamRule;
 import org.graylog2.restclient.models.StreamRuleService;
 import org.graylog2.restclient.models.api.requests.streams.CreateStreamRuleRequest;
 import org.graylog2.restclient.models.api.responses.streams.CreateStreamRuleResponse;
 import org.graylog2.restclient.models.api.results.StreamRulesResult;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -41,12 +41,12 @@ public class StreamRulesApiController extends AuthenticatedController {
         for (StreamRule.Type type : StreamRule.Type.values()) {
             types.add(new Type(type.getId(), type.getShortDesc(), type.getLongDesc()));
         }
-        return ok(Json.toJson(types));
+        return ok(Json.toJsonString(types)).as("application/json");
     }
 
     public Result list(String streamId) throws IOException, APIException {
         final StreamRulesResult result = streamRuleService.all(streamId);
-        return ok(Json.toJson(result));
+        return ok(Json.toJsonString(result)).as("application/json");
     }
 
     public Result update(String streamId, String streamRuleId) throws APIException, IOException {
@@ -65,6 +65,6 @@ public class StreamRulesApiController extends AuthenticatedController {
         final JsonNode json = request().body().asJson();
         final CreateStreamRuleRequest request = Json.fromJson(json, CreateStreamRuleRequest.class);
         final CreateStreamRuleResponse result = streamRuleService.create(streamId, request);
-        return ok(Json.toJson(result));
+        return ok(Json.toJsonString(result)).as("application/json");
     }
 }

--- a/app/controllers/api/StreamRulesApiController.java
+++ b/app/controllers/api/StreamRulesApiController.java
@@ -2,6 +2,7 @@ package controllers.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
@@ -41,12 +42,12 @@ public class StreamRulesApiController extends AuthenticatedController {
         for (StreamRule.Type type : StreamRule.Type.values()) {
             types.add(new Type(type.getId(), type.getShortDesc(), type.getLongDesc()));
         }
-        return ok(Json.toJsonString(types)).as("application/json");
+        return ok(Json.toJsonString(types)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result list(String streamId) throws IOException, APIException {
         final StreamRulesResult result = streamRuleService.all(streamId);
-        return ok(Json.toJsonString(result)).as("application/json");
+        return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result update(String streamId, String streamRuleId) throws APIException, IOException {
@@ -65,6 +66,6 @@ public class StreamRulesApiController extends AuthenticatedController {
         final JsonNode json = request().body().asJson();
         final CreateStreamRuleRequest request = Json.fromJson(json, CreateStreamRuleRequest.class);
         final CreateStreamRuleResponse result = streamRuleService.create(streamId, request);
-        return ok(Json.toJsonString(result)).as("application/json");
+        return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
     }
 }

--- a/app/controllers/api/StreamsApiController.java
+++ b/app/controllers/api/StreamsApiController.java
@@ -3,6 +3,7 @@ package controllers.api;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import models.descriptions.StreamDescription;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.Stream;
@@ -10,7 +11,6 @@ import org.graylog2.restclient.models.StreamService;
 import org.graylog2.restclient.models.api.requests.streams.CreateStreamRequest;
 import org.graylog2.restclient.models.api.requests.streams.TestMatchRequest;
 import org.graylog2.restclient.models.api.responses.streams.TestMatchResponse;
-import play.libs.Json;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -28,11 +28,11 @@ public class StreamsApiController extends AuthenticatedController {
     public Result list() throws IOException, APIException {
         final List<Stream> streams  = this.streamService.all();
 
-        return ok(Json.toJson(streams));
+        return ok(Json.toJsonString(streams)).as("application/json");
     }
 
     public Result get(String streamId) throws IOException, APIException {
-        return ok(Json.toJson(streamService.get(streamId)));
+        return ok(Json.toJsonString(streamService.get(streamId))).as("application/json");
     }
 
     public Result delete(String streamId) throws APIException, IOException {
@@ -44,7 +44,7 @@ public class StreamsApiController extends AuthenticatedController {
         final JsonNode json = request().body().asJson();
         final CreateStreamRequest request = Json.fromJson(json, CreateStreamRequest.class);
 
-        return ok(Json.toJson(this.streamService.create(request)));
+        return ok(Json.toJsonString(this.streamService.create(request))).as("application/json");
     }
 
     public Result pause(String streamId) throws APIException, IOException {
@@ -78,7 +78,7 @@ public class StreamsApiController extends AuthenticatedController {
             final JsonNode jsonNode = request().body().asJson();
             final TestMatchRequest tmr = Json.fromJson(jsonNode, TestMatchRequest.class);
             final TestMatchResponse response = streamService.testMatch(stream_id, tmr);
-            return ok(Json.toJson(response));
+            return ok(Json.toJsonString(response)).as("application/json");
         } catch (APIException e) {
             String message = "Could not test stream rule matching. We expected HTTP 201, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, message);
@@ -100,6 +100,6 @@ public class StreamsApiController extends AuthenticatedController {
             return status(500, "Could not load streams, received HTTP " + e.getHttpCode() + ": " + e.getMessage());
         }
 
-        return ok(Json.toJson(streamDescriptions));
+        return ok(Json.toJsonString(streamDescriptions)).as("application/json");
     }
 }

--- a/app/controllers/api/StreamsApiController.java
+++ b/app/controllers/api/StreamsApiController.java
@@ -2,6 +2,7 @@ package controllers.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import models.descriptions.StreamDescription;
@@ -28,11 +29,11 @@ public class StreamsApiController extends AuthenticatedController {
     public Result list() throws IOException, APIException {
         final List<Stream> streams  = this.streamService.all();
 
-        return ok(Json.toJsonString(streams)).as("application/json");
+        return ok(Json.toJsonString(streams)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result get(String streamId) throws IOException, APIException {
-        return ok(Json.toJsonString(streamService.get(streamId))).as("application/json");
+        return ok(Json.toJsonString(streamService.get(streamId))).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result delete(String streamId) throws APIException, IOException {
@@ -44,7 +45,7 @@ public class StreamsApiController extends AuthenticatedController {
         final JsonNode json = request().body().asJson();
         final CreateStreamRequest request = Json.fromJson(json, CreateStreamRequest.class);
 
-        return ok(Json.toJsonString(this.streamService.create(request))).as("application/json");
+        return ok(Json.toJsonString(this.streamService.create(request))).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result pause(String streamId) throws APIException, IOException {
@@ -78,7 +79,7 @@ public class StreamsApiController extends AuthenticatedController {
             final JsonNode jsonNode = request().body().asJson();
             final TestMatchRequest tmr = Json.fromJson(jsonNode, TestMatchRequest.class);
             final TestMatchResponse response = streamService.testMatch(stream_id, tmr);
-            return ok(Json.toJsonString(response)).as("application/json");
+            return ok(Json.toJsonString(response)).as(MediaType.JSON_UTF_8.toString());
         } catch (APIException e) {
             String message = "Could not test stream rule matching. We expected HTTP 201, but got a HTTP " + e.getHttpCode() + ".";
             return status(504, message);
@@ -100,6 +101,6 @@ public class StreamsApiController extends AuthenticatedController {
             return status(500, "Could not load streams, received HTTP " + e.getHttpCode() + ": " + e.getMessage());
         }
 
-        return ok(Json.toJsonString(streamDescriptions)).as("application/json");
+        return ok(Json.toJsonString(streamDescriptions)).as(MediaType.JSON_UTF_8.toString());
     }
 }

--- a/app/controllers/api/SystemApiController.java
+++ b/app/controllers/api/SystemApiController.java
@@ -20,6 +20,7 @@ package controllers.api;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
@@ -67,7 +68,7 @@ public class SystemApiController extends AuthenticatedController {
         Map<String, Set<String>> result = Maps.newHashMap();
         result.put("fields", fields);
 
-        return ok(Json.toJsonString(result)).as("application/json");
+        return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result jobs() {
@@ -85,7 +86,7 @@ public class SystemApiController extends AuthenticatedController {
             Map<String, Object> result = Maps.newHashMap();
             result.put("jobs", jobs);
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -99,7 +100,7 @@ public class SystemApiController extends AuthenticatedController {
             result.put("count", clusterService.allNotifications().size());*/
             List<Notification> notifications = clusterService.allNotifications();
 
-            return ok(Json.toJsonString(notifications)).as("application/json");
+            return ok(Json.toJsonString(notifications)).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -126,7 +127,7 @@ public class SystemApiController extends AuthenticatedController {
         result.put("throughput", throughputPerNodes._1);
         result.put("nodecount", throughputPerNodes._2);
 
-        return ok(Json.toJsonString(result)).as("application/json");
+        return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result nodeThroughput(String nodeId) {
@@ -135,7 +136,7 @@ public class SystemApiController extends AuthenticatedController {
             final Node node = nodeService.loadNode(nodeId);
             result.put("throughput", node.getThroughput());
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         }
@@ -147,7 +148,7 @@ public class SystemApiController extends AuthenticatedController {
             final Radio radio = nodeService.loadRadio(radioId);
             result.put("throughput", radio.getThroughput());
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         }
@@ -159,7 +160,7 @@ public class SystemApiController extends AuthenticatedController {
             final Stream stream = streamService.get(streamId);
             long throughput = stream.getThroughput();
             result.put("throughput", throughput);
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (APIException e) {
             return status(504, "Could not load stream " + streamId);
         } catch (IOException e) {
@@ -172,7 +173,7 @@ public class SystemApiController extends AuthenticatedController {
             Map<String, Object> result = Maps.newHashMap();
             Node node = nodeService.loadNode(nodeId);
 
-            return ok(Json.toJsonString(jvmMap(node.jvm(), node.getBufferInfo()))).as("application/json");
+            return ok(Json.toJsonString(jvmMap(node.jvm(), node.getBufferInfo()))).as(MediaType.JSON_UTF_8.toString());
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         }
@@ -186,7 +187,7 @@ public class SystemApiController extends AuthenticatedController {
 
             result.put("uncommitted_entries", journalInfo.uncommittedJournalEntries);
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         }
@@ -195,7 +196,7 @@ public class SystemApiController extends AuthenticatedController {
     public Result radioHeap(String radioId) {
         try {
             Radio radio = nodeService.loadRadio(radioId);
-            return ok(Json.toJsonString(jvmMap(radio.jvm(), radio.getBuffers()))).as("application/json");
+            return ok(Json.toJsonString(jvmMap(radio.jvm(), radio.getBuffers()))).as(MediaType.JSON_UTF_8.toString());
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "radio not found");
         }
@@ -242,7 +243,7 @@ public class SystemApiController extends AuthenticatedController {
             Meter meter = (Meter) node.getSingleMetric("org.apache.log4j.Appender.all");
             result.put("total", meter.getTotal());
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         } catch (IOException e) {
@@ -279,7 +280,7 @@ public class SystemApiController extends AuthenticatedController {
                 result.put(shortName, meterMap);
             }
 
-            return ok(Json.toJsonString(result)).as("application/json");
+            return ok(Json.toJsonString(result)).as(MediaType.JSON_UTF_8.toString());
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         } catch (IOException e) {

--- a/app/controllers/api/SystemApiController.java
+++ b/app/controllers/api/SystemApiController.java
@@ -21,6 +21,7 @@ package controllers.api;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import controllers.AuthenticatedController;
+import lib.json.Json;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.metrics.Meter;
 import org.graylog2.restclient.models.BufferInfo;
@@ -36,7 +37,6 @@ import org.graylog2.restclient.models.StreamService;
 import org.graylog2.restclient.models.SystemJob;
 import org.graylog2.restclient.models.api.responses.JournalInfo;
 import play.libs.F;
-import play.libs.Json;
 import play.mvc.BodyParser;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -67,7 +67,7 @@ public class SystemApiController extends AuthenticatedController {
         Map<String, Set<String>> result = Maps.newHashMap();
         result.put("fields", fields);
 
-        return ok(Json.toJson(result));
+        return ok(Json.toJsonString(result)).as("application/json");
     }
 
     public Result jobs() {
@@ -85,7 +85,7 @@ public class SystemApiController extends AuthenticatedController {
             Map<String, Object> result = Maps.newHashMap();
             result.put("jobs", jobs);
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -99,7 +99,7 @@ public class SystemApiController extends AuthenticatedController {
             result.put("count", clusterService.allNotifications().size());*/
             List<Notification> notifications = clusterService.allNotifications();
 
-            return ok(Json.toJson(notifications));
+            return ok(Json.toJsonString(notifications)).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -126,7 +126,7 @@ public class SystemApiController extends AuthenticatedController {
         result.put("throughput", throughputPerNodes._1);
         result.put("nodecount", throughputPerNodes._2);
 
-        return ok(Json.toJson(result));
+        return ok(Json.toJsonString(result)).as("application/json");
     }
 
     public Result nodeThroughput(String nodeId) {
@@ -135,7 +135,7 @@ public class SystemApiController extends AuthenticatedController {
             final Node node = nodeService.loadNode(nodeId);
             result.put("throughput", node.getThroughput());
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         }
@@ -147,7 +147,7 @@ public class SystemApiController extends AuthenticatedController {
             final Radio radio = nodeService.loadRadio(radioId);
             result.put("throughput", radio.getThroughput());
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         }
@@ -159,7 +159,7 @@ public class SystemApiController extends AuthenticatedController {
             final Stream stream = streamService.get(streamId);
             long throughput = stream.getThroughput();
             result.put("throughput", throughput);
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (APIException e) {
             return status(504, "Could not load stream " + streamId);
         } catch (IOException e) {
@@ -172,7 +172,7 @@ public class SystemApiController extends AuthenticatedController {
             Map<String, Object> result = Maps.newHashMap();
             Node node = nodeService.loadNode(nodeId);
 
-            return ok(Json.toJson(jvmMap(node.jvm(), node.getBufferInfo())));
+            return ok(Json.toJsonString(jvmMap(node.jvm(), node.getBufferInfo()))).as("application/json");
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         }
@@ -186,7 +186,7 @@ public class SystemApiController extends AuthenticatedController {
 
             result.put("uncommitted_entries", journalInfo.uncommittedJournalEntries);
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         }
@@ -195,7 +195,7 @@ public class SystemApiController extends AuthenticatedController {
     public Result radioHeap(String radioId) {
         try {
             Radio radio = nodeService.loadRadio(radioId);
-            return ok(Json.toJson(jvmMap(radio.jvm(), radio.getBuffers())));
+            return ok(Json.toJsonString(jvmMap(radio.jvm(), radio.getBuffers()))).as("application/json");
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "radio not found");
         }
@@ -242,7 +242,7 @@ public class SystemApiController extends AuthenticatedController {
             Meter meter = (Meter) node.getSingleMetric("org.apache.log4j.Appender.all");
             result.put("total", meter.getTotal());
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         } catch (IOException e) {
@@ -279,7 +279,7 @@ public class SystemApiController extends AuthenticatedController {
                 result.put(shortName, meterMap);
             }
 
-            return ok(Json.toJson(result));
+            return ok(Json.toJsonString(result)).as("application/json");
         } catch (NodeService.NodeNotFoundException e) {
             return status(404, "node not found");
         } catch (IOException e) {

--- a/app/controllers/api/ToolsApiController.java
+++ b/app/controllers/api/ToolsApiController.java
@@ -18,6 +18,7 @@
 package controllers.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.net.MediaType;
 import com.google.inject.Inject;
 import controllers.AuthenticatedController;
 import lib.NaturalDateTest;
@@ -65,7 +66,7 @@ public class ToolsApiController extends AuthenticatedController {
                 return badRequest();
             }
 
-            return ok(Json.toJsonString(regexTest.test(request))).as("application/json");
+            return ok(Json.toJsonString(regexTest.test(request))).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -81,7 +82,7 @@ public class ToolsApiController extends AuthenticatedController {
                 return badRequest();
             }
 
-            return ok(Json.toJsonString(substringTest.test(request))).as("application/json");
+            return ok(Json.toJsonString(substringTest.test(request))).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -98,7 +99,7 @@ public class ToolsApiController extends AuthenticatedController {
                 return badRequest();
             }
 
-            return ok(Json.toJsonString(splitAndIndexTest.test(request))).as("application/json");
+            return ok(Json.toJsonString(splitAndIndexTest.test(request))).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -112,7 +113,7 @@ public class ToolsApiController extends AuthenticatedController {
         }
 
         try {
-            return ok(Json.toJsonString(naturalDateTest.test(string))).as("application/json");
+            return ok(Json.toJsonString(naturalDateTest.test(string))).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -132,7 +133,7 @@ public class ToolsApiController extends AuthenticatedController {
         }
 
         try {
-            return ok(Json.toJsonString(grokTest.test(request))).as("application/json");
+            return ok(Json.toJsonString(grokTest.test(request))).as(MediaType.JSON_UTF_8.toString());
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/controllers/api/ToolsApiController.java
+++ b/app/controllers/api/ToolsApiController.java
@@ -25,12 +25,12 @@ import lib.extractors.testers.GrokTest;
 import lib.extractors.testers.RegexTest;
 import lib.extractors.testers.SplitAndIndexTest;
 import lib.extractors.testers.SubstringTest;
-import org.graylog2.restclient.lib.APIException;
-import org.graylog2.rest.models.tools.requests.RegexTestRequest;
+import lib.json.Json;
 import org.graylog2.rest.models.tools.requests.GrokTestRequest;
+import org.graylog2.rest.models.tools.requests.RegexTestRequest;
 import org.graylog2.rest.models.tools.requests.SplitAndIndexTestRequest;
 import org.graylog2.rest.models.tools.requests.SubstringTestRequest;
-import play.libs.Json;
+import org.graylog2.restclient.lib.APIException;
 import play.mvc.Result;
 
 import java.io.IOException;
@@ -65,7 +65,7 @@ public class ToolsApiController extends AuthenticatedController {
                 return badRequest();
             }
 
-            return ok(Json.toJson(regexTest.test(request)));
+            return ok(Json.toJsonString(regexTest.test(request))).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -81,7 +81,7 @@ public class ToolsApiController extends AuthenticatedController {
                 return badRequest();
             }
 
-            return ok(Json.toJson(substringTest.test(request)));
+            return ok(Json.toJsonString(substringTest.test(request))).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -98,7 +98,7 @@ public class ToolsApiController extends AuthenticatedController {
                 return badRequest();
             }
 
-            return ok(Json.toJson(splitAndIndexTest.test(request)));
+            return ok(Json.toJsonString(splitAndIndexTest.test(request))).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -112,7 +112,7 @@ public class ToolsApiController extends AuthenticatedController {
         }
 
         try {
-            return ok(Json.toJson(naturalDateTest.test(string)));
+            return ok(Json.toJsonString(naturalDateTest.test(string))).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {
@@ -132,7 +132,7 @@ public class ToolsApiController extends AuthenticatedController {
         }
 
         try {
-            return ok(Json.toJson(grokTest.test(request)));
+            return ok(Json.toJsonString(grokTest.test(request))).as("application/json");
         } catch (IOException e) {
             return internalServerError("io exception");
         } catch (APIException e) {

--- a/app/controllers/api/UsersApiController.java
+++ b/app/controllers/api/UsersApiController.java
@@ -19,12 +19,12 @@ package controllers.api;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import controllers.*;
+import controllers.AuthenticatedController;
+import lib.json.Json;
 import lib.security.RestPermissions;
 import org.graylog2.restclient.models.User;
 import org.graylog2.restclient.models.UserService;
 import org.graylog2.restclient.models.api.responses.system.UserResponse;
-import play.libs.Json;
 import play.mvc.BodyParser;
 import play.mvc.Result;
 import views.helpers.Permissions;
@@ -61,7 +61,7 @@ public class UsersApiController extends AuthenticatedController {
             response.add(userResponse);
         }
 
-        return ok(Json.toJson(response));
+        return ok(Json.toJsonString(response)).as("application/json");
     }
 
     public Result loadUser(String username) {
@@ -71,7 +71,7 @@ public class UsersApiController extends AuthenticatedController {
 
         User user = userService.load(username);
         if (user != null) {
-            return ok(Json.toJson(user));
+            return ok(Json.toJsonString(user)).as("application/json");
         } else {
             return notFound();
         }

--- a/app/controllers/api/UsersApiController.java
+++ b/app/controllers/api/UsersApiController.java
@@ -19,6 +19,7 @@ package controllers.api;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import lib.security.RestPermissions;
@@ -61,7 +62,7 @@ public class UsersApiController extends AuthenticatedController {
             response.add(userResponse);
         }
 
-        return ok(Json.toJsonString(response)).as("application/json");
+        return ok(Json.toJsonString(response)).as(MediaType.JSON_UTF_8.toString());
     }
 
     public Result loadUser(String username) {
@@ -71,7 +72,7 @@ public class UsersApiController extends AuthenticatedController {
 
         User user = userService.load(username);
         if (user != null) {
-            return ok(Json.toJsonString(user)).as("application/json");
+            return ok(Json.toJsonString(user)).as(MediaType.JSON_UTF_8.toString());
         } else {
             return notFound();
         }

--- a/app/lib/Global.java
+++ b/app/lib/Global.java
@@ -18,12 +18,7 @@
  */
 package lib;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -32,6 +27,7 @@ import com.google.inject.Module;
 import com.google.inject.name.Names;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import lib.json.Json;
 import lib.security.PlayAuthenticationListener;
 import lib.security.RedirectAuthenticator;
 import lib.security.RethrowingFirstSuccessfulStrategy;
@@ -66,7 +62,6 @@ import play.Configuration;
 import play.GlobalSettings;
 import play.api.mvc.EssentialFilter;
 import play.libs.F;
-import play.libs.Json;
 import play.mvc.Http;
 import play.mvc.Result;
 
@@ -145,7 +140,7 @@ public class Global extends GlobalSettings {
         // Dirty hack to disable the play2-graylog2 AccessLog if the plugin isn't there
         gelfAccessLog = app.configuration().getBoolean("graylog2.appender.send-access-log", false);
 
-        final ObjectMapper objectMapper = buildObjectMapper();
+        final ObjectMapper objectMapper = Json.buildObjectMapper();
         Json.setObjectMapper(objectMapper);
 
         final List<Module> modules = Lists.newArrayList();
@@ -196,15 +191,6 @@ public class Global extends GlobalSettings {
         }
         SecurityUtils.setSecurityManager(securityManager);
 
-    }
-
-    public static ObjectMapper buildObjectMapper() {
-        return new ObjectMapper()
-                .registerModules(new GuavaModule(), new JodaModule())
-                .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
-                .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     @Override

--- a/app/lib/Global.java
+++ b/app/lib/Global.java
@@ -198,7 +198,7 @@ public class Global extends GlobalSettings {
 
     }
 
-    private ObjectMapper buildObjectMapper() {
+    public static ObjectMapper buildObjectMapper() {
         return new ObjectMapper()
                 .registerModules(new GuavaModule(), new JodaModule())
                 .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)

--- a/app/lib/json/Json.java
+++ b/app/lib/json/Json.java
@@ -17,14 +17,18 @@
 
 package lib.json;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lib.Global;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 import java.io.IOException;
 
 public class Json extends play.libs.Json {
 
-    protected final static ObjectMapper objectMapper = Global.buildObjectMapper();
+    protected final static ObjectMapper objectMapper = buildObjectMapper();
 
     /**
      * Convert an Object to its string representation using the global ObjectMapper.
@@ -37,5 +41,14 @@ public class Json extends play.libs.Json {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static ObjectMapper buildObjectMapper() {
+        return new ObjectMapper()
+                .registerModules(new GuavaModule(), new JodaModule())
+                .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+                .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 }

--- a/app/lib/json/Json.java
+++ b/app/lib/json/Json.java
@@ -1,0 +1,41 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package lib.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lib.Global;
+
+import java.io.IOException;
+
+public class Json extends play.libs.Json {
+
+    protected final static ObjectMapper objectMapper = Global.buildObjectMapper();
+
+    /**
+     * Convert an Object to its string representation using the global ObjectMapper.
+     * Use this method instead of Json.toJson() to ensure that your Double objects are
+     * correctly serialized.
+     */
+    public static String toJsonString(final Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/app/views/alerts/manage.scala.html
+++ b/app/views/alerts/manage.scala.html
@@ -7,7 +7,7 @@
         alarmCallbacks: List[org.graylog2.restclient.models.AlarmCallback],
         node: org.graylog2.restclient.models.Node)
 
-@import play.libs.Json
+@import lib.json.Json
 @import lib.security.RestPermissions._
 @import views.helpers.Permissions._
 @import views.helpers.Permissions
@@ -71,7 +71,7 @@
                 on <a href="https://www.graylog.org/resources/integrations/" target="_blank">the Graylog website</a>.
             </p>
 
-            <div class="react-alarmcallback-component" data-permissions='@Json.toJson(currentUser.getPermissions)' data-stream-id='@stream.getId'>
+            <div class="react-alarmcallback-component" data-permissions='@Json.toJsonString(currentUser.getPermissions)' data-stream-id='@stream.getId'>
             </div>
         </div>
     </div>

--- a/app/views/helpers/Permissions.java
+++ b/app/views/helpers/Permissions.java
@@ -19,6 +19,7 @@
 package views.helpers;
 
 import com.google.common.collect.Maps;
+import lib.json.Json;
 import lib.security.RestPermissions;
 import org.graylog2.restclient.models.User;
 import org.graylog2.restclient.models.UserService;
@@ -26,8 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-
-import static play.libs.Json.toJson;
 
 public class Permissions {
 
@@ -84,7 +83,7 @@ public class Permissions {
             permissionMap.put(permission.name(), isPermitted(permission));
         }
 
-        return toJson(permissionMap).toString();
+        return Json.toJsonString(permissionMap);
     }
 
 }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,5 +1,5 @@
 @(title: String, sidebarContent: Html, searchQuery: String = "", currentUser: org.graylog2.restclient.models.User, reactSearch: Boolean = true)(content: Html)(implicit stream: org.graylog2.restclient.models.Stream = null)
-@import play.libs.Json
+@import lib.json.Json
 @import views.helpers.Permissions._
 @import lib.security.RestPermissions._
 @import org.graylog2.restclient.lib.Configuration
@@ -11,7 +11,7 @@
     <head>
         <title>Graylog - @title</title>
         <script type="text/javascript">
-            var userPreferences = @Html(Json.stringify(Json.toJson(currentUser.getPreferences)));
+            var userPreferences = @Html(Json.toJsonString(currentUser.getPreferences));
         </script>
         <meta name="robots" content="noindex, nofollow">
       	@partials.head()

--- a/app/views/search/index.scala.html
+++ b/app/views/search/index.scala.html
@@ -13,7 +13,7 @@
         inputs: Map[String, models.descriptions.InputDescription]
         )(implicit stream: org.graylog2.restclient.models.Stream)
 
-@import play.libs.Json;
+@import lib.json.Json
 @import models.descriptions.StreamDescription
 @import views.helpers.Permissions
 @import lib.security.RestPermissions._
@@ -32,16 +32,16 @@
             data-query="@query"
             data-built-query="@searchResult.getBuiltQuery"
             data-current-page="@page"
-            data-selected-fields="@Json.toJson(selectedFields)"
+            data-selected-fields="@Json.toJsonString(selectedFields)"
             data-timerange="@search.getTimeRange"
-            data-search-result="@Json.toJson(searchResult)"
-            data-histogram="@Json.toJson(histogram)"
+            data-search-result="@Json.toJsonString(searchResult)"
+            data-histogram="@Json.toJsonString(histogram)"
             data-formatted-histogram="@formattedHistogramResults"
-            data-streams="@Json.toJson(streams)"
-            data-inputs="@Json.toJson(inputs)"
-            data-nodes="@Json.toJson(nodes)"
-            data-search-in-stream="@Json.toJson(StreamDescription.of(stream))"
-            data-permissions="@Json.toJson(currentUser.getPermissions)"
+            data-streams="@Json.toJsonString(streams)"
+            data-inputs="@Json.toJsonString(inputs)"
+            data-nodes="@Json.toJsonString(nodes)"
+            data-search-in-stream="@Json.toJsonString(StreamDescription.of(stream))"
+            data-permissions="@Json.toJsonString(currentUser.getPermissions)"
         >
     </div>
 }

--- a/app/views/search/show_message.scala.html
+++ b/app/views/search/show_message.scala.html
@@ -5,14 +5,14 @@
         inputs: Map[String, models.descriptions.InputDescription]
         )
 
-@import play.libs.Json;
+@import lib.json.Json
 
 @main("Message " + message.getId, null, "", currentUser, true) {
 
     <div id="react-message-details"
-      data-message="@Json.toJson(message)"
-      data-nodes="@Json.toJson(nodes)"
-      data-streams="@Json.toJson(streams)"
-      data-inputs="@Json.toJson(inputs)">
+      data-message="@Json.toJsonString(message)"
+      data-nodes="@Json.toJsonString(nodes)"
+      data-streams="@Json.toJsonString(streams)"
+      data-inputs="@Json.toJsonString(inputs)">
     </div>
 }

--- a/app/views/streamrules/index.scala.html
+++ b/app/views/streamrules/index.scala.html
@@ -1,6 +1,6 @@
 @(currentUser: org.graylog2.restclient.models.User, stream: org.graylog2.restclient.models.Stream, streamrules: List[org.graylog2.restclient.models.StreamRule])
 
-@import play.libs.Json
+@import lib.json.Json
 
 @main("Rules of stream \"" + stream.getTitle + "\"" , null, "", currentUser, false) {
 
@@ -16,6 +16,6 @@
     </div>
 
 
-    <div class="react-streamrules-editor" data-stream-id="@stream.getId" data-permissions='@Json.toJson(currentUser.getPermissions)'>
+    <div class="react-streamrules-editor" data-stream-id="@stream.getId" data-permissions='@Json.toJsonString(currentUser.getPermissions)'>
     </div>
 }

--- a/app/views/streams/index.scala.html
+++ b/app/views/streams/index.scala.html
@@ -1,8 +1,8 @@
 @(currentUser: org.graylog2.restclient.models.User)
 
-@import play.libs.Json
+@import lib.json.Json
 
 @main("Streams", null, "", currentUser, false) {
-    <div class="react-stream-component" data-permissions='@Json.toJson(currentUser.getPermissions)' data-user-name="@currentUser.getName">
+    <div class="react-stream-component" data-permissions='@Json.toJsonString(currentUser.getPermissions)' data-user-name="@currentUser.getName">
     </div>
 }

--- a/app/views/streams/outputs/index.scala.html
+++ b/app/views/streams/outputs/index.scala.html
@@ -2,7 +2,7 @@
     breadcrumbs: lib.BreadcrumbList,
     stream: org.graylog2.restclient.models.Stream)
 
-@import play.libs.Json;
+@import lib.json.Json
 
 @main("Outputs of stream \"" + stream.getTitle + "\"", null, "", currentUser, false) {
 
@@ -29,6 +29,6 @@
         </div>
     </div>
 
-    <div class="react-output-component" data-stream-id="@stream.getId" data-permissions='@Json.toJson(currentUser.getPermissions)'>
+    <div class="react-output-component" data-stream-id="@stream.getId" data-permissions='@Json.toJsonString(currentUser.getPermissions)'>
     </div>
 }

--- a/javascript/src/components/search/FieldGraphs.jsx
+++ b/javascript/src/components/search/FieldGraphs.jsx
@@ -29,7 +29,7 @@ var FieldGraphs = React.createClass({
         };
     },
     addFieldGraph(field) {
-        var streamId = this.props.searchInStream !== undefined ? this.props.searchInStream.id : undefined;
+        var streamId = this.props.searchInStream ? this.props.searchInStream.id : undefined;
         FieldGraphsStore.newFieldGraph(field, {interval: this.props.resolution, streamid: streamId});
     },
     deleteFieldGraph(graphId) {

--- a/javascript/src/stores/field-analyzers/FieldQuickValuesStore.ts
+++ b/javascript/src/stores/field-analyzers/FieldQuickValuesStore.ts
@@ -13,8 +13,7 @@ import UserNotification = require('../../util/UserNotification');
 var FieldQuickValuesStore = {
     getQuickValues(field: string): JQueryPromise<string[]> {
         var originalSearchURLParams = SearchStore.getOriginalSearchURLParams();
-        var searchInStream = SearchStore.searchInStream;
-        var streamId = searchInStream === undefined ? null : searchInStream.id;
+        var streamId = SearchStore.searchInStream ? SearchStore.searchInStream.id : null;
 
         var url = jsRoutes.controllers.api.SearchApiController.fieldTerms(
             originalSearchURLParams.get('q'),

--- a/javascript/src/stores/field-analyzers/FieldStatisticsStore.ts
+++ b/javascript/src/stores/field-analyzers/FieldStatisticsStore.ts
@@ -24,8 +24,7 @@ var FieldStatisticsStore = {
     }),
     getFieldStatistics(field: string): JQueryPromise<string[]> {
         var originalSearchURLParams = SearchStore.getOriginalSearchURLParams();
-        var searchInStream = SearchStore.searchInStream;
-        var streamId = searchInStream === undefined ? null : searchInStream.id;
+        var streamId = SearchStore.searchInStream ? SearchStore.searchInStream.id : null;
 
         var url = jsRoutes.controllers.api.SearchApiController.fieldStats(
             originalSearchURLParams.get('q'),


### PR DESCRIPTION
Using `Json.toJson` does not properly serialize certain objects into JSON, like doubles that are not a number, e.g. `Double.NaN`.

These changes extend the `Json` play class to include the `toJsonString` method, which uses the default `ObjectMapper` to generate the JSON string representation, and use that method along the codebase.

It feels a bit odd adding that new method to simply use the `ObjectMapper`, but sometimes we generate JSON from the views, and using it from there feels also messy.
