### PR TITLE
Feature: Stream OR-Operator UI

### DIFF
--- a/app/controllers/api/StreamsApiController.java
+++ b/app/controllers/api/StreamsApiController.java
@@ -6,6 +6,7 @@ import com.google.common.net.MediaType;
 import controllers.AuthenticatedController;
 import lib.json.Json;
 import models.descriptions.StreamDescription;
+import org.graylog2.rest.models.streams.requests.UpdateStreamRequest;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.models.Stream;
 import org.graylog2.restclient.models.StreamService;
@@ -60,7 +61,7 @@ public class StreamsApiController extends AuthenticatedController {
 
     public Result update(String streamId) throws APIException, IOException {
         final JsonNode json = request().body().asJson();
-        final CreateStreamRequest request = Json.fromJson(json, CreateStreamRequest.class);
+        final UpdateStreamRequest request = Json.fromJson(json, UpdateStreamRequest.class);
 
         this.streamService.update(streamId, request);
         return ok();

--- a/javascript/src/components/streamrules/StreamRulesEditor.jsx
+++ b/javascript/src/components/streamrules/StreamRulesEditor.jsx
@@ -1,128 +1,132 @@
 /* global jsRoutes */
 
-'use strict';
+import React from 'react';
+import { PropTypes } from 'react';
+import LoaderTabs from '../messageloaders/LoaderTabs';
+import StreamRuleList from './StreamRuleList';
+import StreamsStore from '../../stores/streams/StreamsStore';
+import StreamRulesStore from '../../stores/streams/StreamRulesStore';
+import { Alert } from 'react-bootstrap';
+import StreamRuleForm from './StreamRuleForm';
+import Spinner from '../common/Spinner';
+import MatchingTypeSwitcher from '../streams/MatchingTypeSwitcher';
 
-var React = require('react');
-var LoaderTabs = require('../messageloaders/LoaderTabs');
-var StreamRuleList = require('./StreamRuleList');
-var StreamsStore = require('../../stores/streams/StreamsStore');
-var StreamRulesStore = require('../../stores/streams/StreamRulesStore');
-var Alert = require('react-bootstrap').Alert;
-var StreamRuleForm = require('./StreamRuleForm');
-var Spinner = require('../common/Spinner');
-var MatchingTypeSwitcher = require('../streams/MatchingTypeSwitcher');
+const StreamRulesEditor = React.createClass({
+  propTypes() {
+    return {
+      streamId: PropTypes.string.isRequired,
+    };
+  },
+  componentDidMount() {
+    this.loadData();
+    StreamsStore.onChange(this.loadData);
+    StreamRulesStore.onChange(this.loadData);
+  },
+  getInitialState() {
+    return {};
+  },
+  onMessageLoaded(message) {
+    this.setState({message: message});
+    StreamsStore.testMatch(this.props.streamId, {message: message.fields}, (resultData) => {
+      this.setState({matchData: resultData});
+    });
+  },
+  render() {
+    const styles = (this.state.matchData ? this._getListClassName(this.state.matchData) : 'info');
+    if (this.state.stream && this.state.streamRuleTypes) {
+      return (
+        <div className="row content">
+          <div className="col-md-12 streamrule-sample-message">
+            <h2>
+              1. Load a message to test rules
+            </h2>
 
-var StreamRulesEditor = React.createClass({
-    getInitialState() {
-        return {};
-    },
-    onMessageLoaded(message) {
-        this.setState({message: message});
-        StreamsStore.testMatch(this.props.streamId, {message: message.fields}, (resultData) => {
-            this.setState({matchData: resultData});
-        });
-    },
-    _onStreamRuleFormSubmit(streamRuleId, data) {
-        StreamRulesStore.create(this.props.streamId, data, () => {});
-    },
-    _onAddStreamRule(event) {
-        event.preventDefault();
-        this.refs.newStreamRuleForm.open();
-    },
-    loadData() {
-        StreamRulesStore.types((types) => {
-            this.setState({streamRuleTypes: types});
-        });
+            <div className="stream-loader">
+              <LoaderTabs messageId={this.props.messageId} index={this.props.index} onMessageLoaded={this.onMessageLoaded}/>
+            </div>
 
-        StreamsStore.get(this.props.streamId, (stream) => {
-            this.setState({stream: stream});
-        });
+            <div className="spinner" style={{display: 'none'}}><h2><i
+              className="fa fa-spinner fa-spin"></i> &nbsp;Loading message</h2></div>
 
-        if (this.state.message) {
-            this.onMessageLoaded(this.state.message);
-        }
-    },
-    componentDidMount() {
-        this.loadData();
-        StreamsStore.onChange(this.loadData);
-        StreamRulesStore.onChange(this.loadData);
-    },
-    _getListClassName(matchData) {
-        return (matchData.matches ? "success" : "danger");
-    },
-    _explainMatchResult() {
-        if (this.state.matchData) {
-            if (this.state.matchData.matches) {
-                return (
-                    <span>
-                        <i className="fa fa-check" style={{"color":"green"}}/> This message would be routed to this stream.
-                    </span>);
-            } else {
-                return (
-                    <span>
-                        <i className="fa fa-remove" style={{"color":"red"}}/> This message would not be routed to this stream.
-                    </span>);
-            }
-        } else {
-            return ("Please load a message to check if it would match against these rules and therefore be routed into this stream.");
-        }
-    },
-    render() {
-        var styles = (this.state.matchData ? this._getListClassName(this.state.matchData) : "info");
-        if (this.state.stream && this.state.streamRuleTypes) {
-            return (
-                <div className="row content">
-                    <div className="col-md-12 streamrule-sample-message">
-                        <h2>
-                            1. Load a message to test rules
-                        </h2>
+            <div className="sample-message-display" style={{display: 'none', marginTop: '5px'}}>
+              <strong>Next step:</strong>
+              Add/delete/modify stream rules in step 2 and see if the example message would have been
+              routed into the stream or not. Use the button on the right to add a stream rule.
+            </div>
 
-                        <div className="stream-loader">
-                            <LoaderTabs messageId={this.props.messageId} index={this.props.index} onMessageLoaded={this.onMessageLoaded}/>
-                        </div>
+            <hr />
 
-                        <div className="spinner" style={{display: "none"}}><h2><i
-                            className='fa fa-spinner fa-spin'></i> &nbsp;Loading message</h2></div>
+            <div className="buttons pull-right">
+              <button className="btn btn-success show-stream-rule" onClick={this._onAddStreamRule}>
+                Add stream rule
+              </button>
+              <StreamRuleForm ref="newStreamRuleForm" title="New Stream Rule"
+                              streamRuleTypes={this.state.streamRuleTypes} onSubmit={this._onStreamRuleFormSubmit}/>
+            </div>
 
-                        <div className="sample-message-display" style={{display: "none", marginTop: "5px"}}>
-                            <strong>Next step:</strong>
-                            Add/delete/modify stream rules in step 2 and see if the example message would have been
-                            routed into the stream or not. Use the button on the right to add a stream rule.
-                        </div>
+            <h2>
+              2. Manage stream rules
+            </h2>
 
-                        <hr />
+            {this._explainMatchResult()}
 
-                        <div className="buttons pull-right">
-                            <button className="btn btn-success show-stream-rule" onClick={this._onAddStreamRule}>
-                                Add stream rule
-                            </button>
-                            <StreamRuleForm ref="newStreamRuleForm" title="New Stream Rule"
-                                            streamRuleTypes={this.state.streamRuleTypes} onSubmit={this._onStreamRuleFormSubmit}/>
-                        </div>
+            <MatchingTypeSwitcher stream={this.state.stream} onChange={this.loadData}/>
+            <Alert ref="well" bsStyle={styles}>
+              <StreamRuleList stream={this.state.stream} streamRuleTypes={this.state.streamRuleTypes}
+                              permissions={this.props.permissions} matchData={this.state.matchData}/>
+            </Alert>
 
-                        <h2>
-                            2. Manage stream rules
-                        </h2>
-
-                        {this._explainMatchResult()}
-
-                        <MatchingTypeSwitcher stream={this.state.stream} onChange={this.loadData}/>
-                        <Alert ref='well' bsStyle={styles}>
-                            <StreamRuleList stream={this.state.stream} streamRuleTypes={this.state.streamRuleTypes}
-                                            permissions={this.props.permissions} matchData={this.state.matchData}/>
-                        </Alert>
-
-                        <p style={{marginTop: '10px'}}>
-                            <a href={jsRoutes.controllers.StreamsController.index().url} className="btn btn-success">I'm
-                                done!</a>
-                        </p>
-                    </div>
-                </div>
-            );
-        } else {
-            return (<div className="row content"><div style={{marginLeft: 10}}><Spinner/></div></div>);
-        }
+            <p style={{marginTop: '10px'}}>
+              <a href={jsRoutes.controllers.StreamsController.index().url} className="btn btn-success">I'm
+                done!</a>
+            </p>
+          </div>
+        </div>
+      );
+    } else {
+      return (<div className="row content"><div style={{marginLeft: 10}}><Spinner/></div></div>);
     }
+  },
+  loadData() {
+    StreamRulesStore.types((types) => {
+      this.setState({streamRuleTypes: types});
+    });
+
+    StreamsStore.get(this.props.streamId, (stream) => {
+      this.setState({stream: stream});
+    });
+
+    if (this.state.message) {
+      this.onMessageLoaded(this.state.message);
+    }
+  },
+  _onStreamRuleFormSubmit(streamRuleId, data) {
+    StreamRulesStore.create(this.props.streamId, data, () => {});
+  },
+  _onAddStreamRule(event) {
+    event.preventDefault();
+    this.refs.newStreamRuleForm.open();
+  },
+  _getListClassName(matchData) {
+    return (matchData.matches ? 'success' : 'danger');
+  },
+  _explainMatchResult() {
+    if (this.state.matchData) {
+      if (this.state.matchData.matches) {
+        return (
+          <span>
+            <i className="fa fa-check" style={{'color': 'green'}}/> This message would be routed to this stream.
+          </span>);
+      } else {
+        return (
+          <span>
+            <i className="fa fa-remove" style={{'color': 'red'}}/> This message would not be routed to this stream.
+          </span>);
+      }
+    } else {
+      return ('Please load a message to check if it would match against these rules and therefore be routed into this stream.');
+    }
+  },
 });
 
 module.exports = StreamRulesEditor;

--- a/javascript/src/components/streamrules/StreamRulesEditor.jsx
+++ b/javascript/src/components/streamrules/StreamRulesEditor.jsx
@@ -10,6 +10,7 @@ var StreamRulesStore = require('../../stores/streams/StreamRulesStore');
 var Alert = require('react-bootstrap').Alert;
 var StreamRuleForm = require('./StreamRuleForm');
 var Spinner = require('../common/Spinner');
+var MatchingTypeSwitcher = require('../streams/MatchingTypeSwitcher');
 
 var StreamRulesEditor = React.createClass({
     getInitialState() {
@@ -54,12 +55,12 @@ var StreamRulesEditor = React.createClass({
             if (this.state.matchData.matches) {
                 return (
                     <span>
-                        <i className="fa fa-check" style={{"color":"green"}}/> This message matches all rules and would be routed to this stream.
+                        <i className="fa fa-check" style={{"color":"green"}}/> This message would be routed to this stream.
                     </span>);
             } else {
                 return (
                     <span>
-                        <i className="fa fa-remove" style={{"color":"red"}}/> This message does not match one or more of the rules and would not be routed to this stream.
+                        <i className="fa fa-remove" style={{"color":"red"}}/> This message would not be routed to this stream.
                     </span>);
             }
         } else {
@@ -105,6 +106,7 @@ var StreamRulesEditor = React.createClass({
 
                         {this._explainMatchResult()}
 
+                        <MatchingTypeSwitcher stream={this.state.stream} onChange={this.loadData}/>
                         <Alert ref='well' bsStyle={styles}>
                             <StreamRuleList stream={this.state.stream} streamRuleTypes={this.state.streamRuleTypes}
                                             permissions={this.props.permissions} matchData={this.state.matchData}/>

--- a/javascript/src/components/streams/MatchingTypeSwitcher.jsx
+++ b/javascript/src/components/streams/MatchingTypeSwitcher.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { PropTypes, Component } from 'react';
+import { Input } from 'react-bootstrap';
+import StreamsStore from '../../stores/streams/StreamsStore';
+
+class MatchingTypeSwitcher extends Component {
+  static propTypes = {
+    stream: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+  }
+  render() {
+    const valueLink = {
+      value: this.props.stream.matching_type,
+      requestChange: this.handleTypeChange,
+      streamId: this.props.stream.id,
+      onChange: this.props.onChange,
+    };
+    return (
+      <div className="form-inline">
+        A message needs to match{' '}
+        <Input type="select" className="form-inline input-sm" valueLink={valueLink}>
+          <option value="AND">all rules</option>
+          <option value="OR">at least one rule</option>
+        </Input>
+        {' '}to be routed into this stream.{' '}
+      </div>
+    );
+  }
+
+  handleTypeChange(newValue) {
+    StreamsStore.update(this.streamId, { 'matching_type': newValue }, this.onChange);
+  }
+}
+
+export default MatchingTypeSwitcher;

--- a/javascript/src/components/streams/MatchingTypeSwitcher.jsx
+++ b/javascript/src/components/streams/MatchingTypeSwitcher.jsx
@@ -7,7 +7,7 @@ class MatchingTypeSwitcher extends Component {
   static propTypes = {
     stream: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  }
+  };
   render() {
     const valueLink = {
       value: this.props.stream.matching_type,

--- a/javascript/src/components/streams/MatchingTypeSwitcher.jsx
+++ b/javascript/src/components/streams/MatchingTypeSwitcher.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes, Component } from 'react';
-import { Input } from 'react-bootstrap';
+import { Input, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import StreamsStore from '../../stores/streams/StreamsStore';
 
 class MatchingTypeSwitcher extends Component {
@@ -11,24 +11,33 @@ class MatchingTypeSwitcher extends Component {
   render() {
     const valueLink = {
       value: this.props.stream.matching_type,
-      requestChange: this.handleTypeChange,
-      streamId: this.props.stream.id,
-      onChange: this.props.onChange,
+      requestChange: this.handleTypeChange.bind(this),
     };
     return (
       <div className="form-inline">
         A message needs to match{' '}
-        <Input type="select" className="form-inline input-sm" valueLink={valueLink}>
-          <option value="AND">all rules</option>
-          <option value="OR">at least one rule</option>
-        </Input>
+        <OverlayTrigger
+          placement="top"
+          ref="savedTooltip"
+          trigger="manual"
+          defaultOverlayShown={false}
+          overlay={<Tooltip>Saved!</Tooltip>}>
+          <Input type="select" className="form-inline input-sm" valueLink={valueLink}>
+            <option value="AND">all rules</option>
+            <option value="OR">at least one rule</option>
+          </Input>
+        </OverlayTrigger>
         {' '}to be routed into this stream.{' '}
       </div>
     );
   }
 
   handleTypeChange(newValue) {
-    StreamsStore.update(this.streamId, { 'matching_type': newValue }, this.onChange);
+    StreamsStore.update(this.props.stream.id, { 'matching_type': newValue }, () => {
+      this.props.onChange();
+      this.refs.savedTooltip.show();
+      window.setTimeout(() => this.refs.savedTooltip.hide(), 1000);
+    });
   }
 }
 

--- a/javascript/src/components/streams/Stream.jsx
+++ b/javascript/src/components/streams/Stream.jsx
@@ -14,9 +14,8 @@ import UserNotification from 'util/UserNotification';
 const Stream = React.createClass({
   propTypes() {
     return {
-      permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
       stream: PropTypes.object.isRequired,
-      streamRuleTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
+      permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
       onResume: PropTypes.func.isRequired,
     };
   },
@@ -24,7 +23,8 @@ const Stream = React.createClass({
   render() {
     const stream = this.props.stream;
     const permissions = this.props.permissions;
-    const editRulesLink = (this.isPermitted(permissions, ['streams:edit:' + stream.id]) ? <a href={jsRoutes.controllers.StreamRulesController.index(stream.id).url} className="btn btn-info">Edit rules</a> : null);
+    const editRulesLink = (this.isPermitted(permissions, ['streams:edit:' + stream.id]) ?
+      <a href={jsRoutes.controllers.StreamRulesController.index(stream.id).url} className="btn btn-info">Edit rules</a> : null);
 
     let manageOutputsLink = null;
     let manageAlertsLink = null;
@@ -35,24 +35,31 @@ const Stream = React.createClass({
                             className="btn btn-info">Manage alerts</a>);
     }
 
-    let toggleStreamLink = null;
+    let toggleStreamLink;
     if (this.isAnyPermitted(permissions, ['streams:changestate:' + stream.id, 'streams:edit:' + stream.id])) {
       if (stream.disabled) {
-        toggleStreamLink = (<a className="btn btn-success toggle-stream-button" onClick={this._onResume}>Start stream</a>);
+        toggleStreamLink = (
+          <a className="btn btn-success toggle-stream-button" onClick={this._onResume}>Start stream</a>
+        );
       } else {
-        toggleStreamLink = (<a className="btn btn-primary toggle-stream-button" onClick={this._onPause}>Pause stream</a>);
+        toggleStreamLink = (
+          <a className="btn btn-primary toggle-stream-button" onClick={this._onPause}>Pause stream</a>
+        );
       }
     }
 
-    const createdFromContentPack = (stream.content_pack ? <i className="fa fa-cube" title="Created from content pack"></i> : null);
+    const createdFromContentPack = (stream.content_pack ?
+      <i className="fa fa-cube" title="Created from content pack"></i> : null);
 
     return (
       <li className="stream">
         <h2>
-          <a href={jsRoutes.controllers.StreamSearchController.index(stream.id, '*', 'relative', 300).url}>{stream.title}</a>
+          <a
+            href={jsRoutes.controllers.StreamSearchController.index(stream.id, '*', 'relative', 300).url}>{stream.title}</a>
 
           <StreamStateBadge stream={stream} onClick={this.props.onResume}/>
         </h2>
+
         <div className="stream-data">
           <div className="stream-actions pull-right">
             {editRulesLink}{' '}
@@ -70,20 +77,29 @@ const Stream = React.createClass({
             {stream.description}
           </div>
           <div className="stream-metadata">
-            <StreamThroughput streamId={stream.id} />
+            <StreamThroughput streamId={stream.id}/>
 
             , {this._formatNumberOfStreamRules(stream)}
 
-            <CollapsibleStreamRuleList key={'streamRules-' + stream.id} stream={stream} streamRuleTypes={this.props.streamRuleTypes}
+            <CollapsibleStreamRuleList key={'streamRules-' + stream.id} stream={stream}
+                                       streamRuleTypes={this.props.streamRuleTypes}
                                        permissions={this.props.permissions}/>
           </div>
         </div>
-        <StreamRuleForm ref="quickAddStreamRuleForm" title="New Stream Rule" onSubmit={this._onSaveStreamRule} streamRuleTypes={this.props.streamRuleTypes}/>
+        <StreamRuleForm ref="quickAddStreamRuleForm" title="New Stream Rule" onSubmit={this._onSaveStreamRule}
+                        streamRuleTypes={this.props.streamRuleTypes}/>
       </li>
     );
   },
   _formatNumberOfStreamRules(stream) {
-    return (stream.stream_rules.length > 0 ? stream.stream_rules.length + ' configured stream rule(s).' : 'no configured rules.');
+    let verbalMatchingType;
+    switch (stream.matching_type) {
+      case 'OR': verbalMatchingType = 'at least one'; break;
+      default:
+      case 'AND': verbalMatchingType = 'all'; break;
+    }
+    return (stream.stream_rules.length > 0 ?
+      'Must match ' + verbalMatchingType + ' of the ' + stream.stream_rules.length + ' configured stream rule(s).' : 'No configured rules.');
   },
   _onDelete(stream) {
     if (window.confirm('Do you really want to remove this stream?')) {
@@ -91,7 +107,8 @@ const Stream = React.createClass({
     }
   },
   _onResume() {
-    StreamsStore.resume(this.props.stream.id, () => {});
+    StreamsStore.resume(this.props.stream.id, () => {
+    });
   },
   _onUpdate(streamId, stream) {
     StreamsStore.update(streamId, stream, () => UserNotification.success('Stream \'' + stream.title + '\' was updated successfully.', 'Success'));
@@ -101,7 +118,8 @@ const Stream = React.createClass({
   },
   _onPause() {
     if (window.confirm('Do you really want to pause stream \'' + this.props.stream.title + '\'?')) {
-      StreamsStore.pause(this.props.stream.id, () => {});
+      StreamsStore.pause(this.props.stream.id, () => {
+      });
     }
   },
   _onQuickAdd() {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ import com.typesafe.sbt.less.Import.LessKeys
 
 object ApplicationBuild extends Build {
   val appName         = "graylog-web-interface"
-  val appVersion      = "1.2.0-SNAPSHOT"
+  val appVersion      = "1.2.0-or-operator-ui-SNAPSHOT"
   val appDependencies = Seq(
     cache,
     javaCore,


### PR DESCRIPTION
This PR adds a simple UI for the matching type of stream. Configuration is done inline in the stream rules editor by adding a simple dropdown in a verbal description of the matching logic. In the streams list, the stream type is indicated in the verbal description of the stream rules summary.
