### PR TITLE
Fix default statistical value for old widgets

### DIFF
--- a/javascript/src/components/widgets/WidgetEditConfigModal.jsx
+++ b/javascript/src/components/widgets/WidgetEditConfigModal.jsx
@@ -185,11 +185,12 @@ var WidgetEditConfigModal = React.createClass({
 
         switch (this.state.type) {
             case this.props.widgetTypes.STATS_COUNT:
+                var defaultStatisticalFunction = this.state.config["stats_function"] === 'stddev' ? 'std_deviation' : this.state.config["stats_function"];
                 controls.push(
                     <Input key="statsCountStatisticalFunction"
                            type="select"
                            label="Statistical function"
-                           defaultValue={this.state.config["stats_function"]}
+                           defaultValue={defaultStatisticalFunction}
                            onChange={this._onStatisticalFunctionChange("stats_function")}
                            help="Statistical function applied to the data.">
                         {FieldStatisticsStore.FUNCTIONS.keySeq().map((statFunction) => {


### PR DESCRIPTION
Select the right statistical function when editing an old statistical widget with standard deviation function.

Graylog server issue: Graylog2/graylog2-server#1380
Related issue: #1565