### PR TITLE
Change default widget titles for streams

### DIFF
--- a/javascript/src/components/dashboard/AddToDashboardMenu.jsx
+++ b/javascript/src/components/dashboard/AddToDashboardMenu.jsx
@@ -104,7 +104,8 @@ var AddToDashboardMenu = React.createClass({
                                      supportsTrending={true}
                                      configuration={this.props.configuration}
                                      onConfigurationSaved={this._saveWidget}
-                                     fields={this.props.fields}/>
+                                     fields={this.props.fields}
+                                     isStreamSearch={this.props.isStreamSearch}/>
             </div>
         );
     }

--- a/javascript/src/components/search/LegacyHistogram.jsx
+++ b/javascript/src/components/search/LegacyHistogram.jsx
@@ -64,7 +64,8 @@ var LegacyHistogram = React.createClass({
                                     widgetType={Widget.Type.SEARCH_RESULT_CHART}
                                     configuration={{interval: this.props.histogram.interval}}
                                     pullRight={true}
-                                    permissions={this.props.permissions}/>
+                                    permissions={this.props.permissions}
+                                    isStreamSearch={this.props.isStreamSearch}/>
             </div>
             <h1>Histogram</h1>
 

--- a/javascript/src/components/search/SearchResult.jsx
+++ b/javascript/src/components/search/SearchResult.jsx
@@ -203,7 +203,8 @@ var SearchResult = React.createClass({
 
                     <LegacyHistogram formattedHistogram={this.props.formattedHistogram}
                                      histogram={this.props.histogram}
-                                     permissions={this.props.permissions}/>
+                                     permissions={this.props.permissions}
+                                     isStreamSearch={this.props.searchInStream !== null}/>
 
                     <FieldGraphs ref='fieldGraphsComponent'
                                  resolution={this.props.histogram['interval']}

--- a/javascript/src/components/widgets/WidgetCreationModal.jsx
+++ b/javascript/src/components/widgets/WidgetCreationModal.jsx
@@ -65,8 +65,10 @@ var WidgetCreationModal = React.createClass({
 
         switch (this.props.widgetType) {
             case Widget.Type.SEARCH_RESULT_COUNT:
-            case Widget.Type.STREAM_SEARCH_RESULT_COUNT:
                 title = "message count";
+                break;
+            case Widget.Type.STREAM_SEARCH_RESULT_COUNT:
+                title = "stream message count";
                 break;
             case Widget.Type.STATS_COUNT:
                 title = "field statistical value";
@@ -86,7 +88,11 @@ var WidgetCreationModal = React.createClass({
                 }
                 break;
             case Widget.Type.SEARCH_RESULT_CHART:
-                title = "search histogram";
+                if (this.props.isStreamSearch) {
+                    title = "stream histogram";
+                } else {
+                    title = "search histogram";
+                }
                 break;
             case Widget.Type.STACKED_CHART:
                 title = "combined graph";


### PR DESCRIPTION
Check if the search scope is in a stream in order to select the default widget titles. Fixes #1476.