### PR TITLE
Improve resilience when ES unavailable

### DIFF
--- a/app/controllers/IndicesController.java
+++ b/app/controllers/IndicesController.java
@@ -21,6 +21,7 @@ import com.google.inject.Inject;
 import lib.BreadcrumbList;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
+import org.graylog2.restclient.lib.Graylog2ServerUnavailableException;
 import org.graylog2.restclient.lib.Tools;
 import org.graylog2.restclient.models.ClusterService;
 import org.graylog2.restclient.models.ESClusterHealth;
@@ -80,6 +81,12 @@ public class IndicesController extends AuthenticatedController {
                     clusterHealth,
                     deflector.currentTarget,
                     deflectorConfig
+            ));
+        } catch (Graylog2ServerUnavailableException e) {
+            return ok(views.html.system.indices.index_cluster_unavailable.render(
+                    currentUser(),
+                    bc,
+                    null
             ));
         } catch (APIException e) {
             String message = "Could not get indices. We expected HTTP 200, but got a HTTP " + e.getHttpCode() + ".";

--- a/app/views/partials/dates/time_configuration.scala.html
+++ b/app/views/partials/dates/time_configuration.scala.html
@@ -19,5 +19,5 @@
     <dt>Web interface configuration:</dt>
     <dd>@DateHelper.timestampShortTZ(DateTime.now(DateTools.getApplicationTimeZone()), false)</dd>
     <dt>Graylog master server:</dt>
-    <dd>@DateHelper.timestampShortTZ(DateTime.now(DateTimeZone.forID(masterTimezone)), false)</dd>
+    <dd>@if(masterTimezone.equals("")) {Graylog master server currently unavailable} else {@DateHelper.timestampShortTZ(DateTime.now(DateTimeZone.forID(masterTimezone)), false)}</dd>
 </dl>

--- a/app/views/partials/indexer_failures.scala.html
+++ b/app/views/partials/indexer_failures.scala.html
@@ -9,12 +9,17 @@
         </a>
     </div>
 } else {
-    <div class="alert alert-success">
-        <i class="fa fa-check-circle"></i> &nbsp;No failed indexing attempts in the last 24 hours.
+    @if(indexFailureCount == 0) {
+        <div class="alert alert-success">
+            <i class="fa fa-check-circle"></i> &nbsp;No failed indexing attempts in the last 24 hours.
 
-
-        <a href="@routes.IndicesController.failures()" class="btn btn-xs pull-right btn-info">
-            Show all errors
-        </a>
-    </div>
+            <a href="@routes.IndicesController.failures()" class="btn btn-xs pull-right btn-info">
+                Show all errors
+            </a>
+        </div>
+    } else {
+        <div class="alert alert-warning">
+            <i class="fa fa-warning"></i> &nbsp;<strong>Failed indexing attempts currently unavailable.</strong>
+        </div>
+    }
 }

--- a/app/views/system/indices/index_cluster_unavailable.scala.html
+++ b/app/views/system/indices/index_cluster_unavailable.scala.html
@@ -2,27 +2,31 @@
         breadcrumbs: lib.BreadcrumbList,
         clusterHealth: org.graylog2.restclient.models.ESClusterHealth)
 
-@main("Indices", null, "", currentUser) {
+@main("Indices", null, "", currentUser, false) {
 
   @views.html.partials.breadcrumbs(breadcrumbs)
 
-  <div class="row">
-    <h1><i class="fa fa-reorder"></i> Indices</h1>
-    This is an overview of all indices (message stores) Graylog is currently taking in account
-    for searches and analysis. You can learn more about the index model in the
-    @views.html.partials.links.docs(views.helpers.DocsHelper.PAGE_INDEX_MODEL, "documentation").
-    Closed indices can be re-opened at any time.
-
-    <br />
+  <div class="row content content-head">
+    <div class="col-md-10">
+      <h1>Indices</h1>
+      <p class="description">
+        This is an overview of all indices (message stores) Graylog is currently taking in account
+        for searches and analysis. You can learn more about the index model in the
+        @views.html.partials.links.docs(views.helpers.DocsHelper.PAGE_INDEX_MODEL, "documentation").
+        Closed indices can be re-opened at any time.
+      </p>
+    </div>
   </div>
 
-  <div class="row">
-    @views.html.partials.es_cluster_health.render(clusterHealth)
+  <div class="row content">
+    <div class="col-md-12">
+      @views.html.partials.es_cluster_health.render(clusterHealth)
 
-    <div class="index-info">
-      <div class="alert alert-danger">
-        <i class="fa fa-info-circle"></i> Indices information is not available at the moment.
-        @if(clusterHealth == null) {Please check again once the cluster is available.}
+      <div class="index-info">
+        <div class="alert alert-danger">
+          <i class="fa fa-info-circle"></i> Indices information is not available at the moment.
+          @if(clusterHealth == null) {Please check again once the cluster is available.}
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
When ES is not available, our System Overview and Indices pages were throwing exceptions, that make them impossible to reach. This commit handles those exceptions.

Fixes #1518.