### PR TITLE
Improve error handling on dashboard widgets

### DIFF
--- a/app/assets/stylesheets/graylog2.less
+++ b/app/assets/stylesheets/graylog2.less
@@ -1270,7 +1270,7 @@ dl.metric-histogram dd {
 }
 
 .dashboard .widget .number .value {
-  line-height: 90px;
+  line-height: 100px;
   text-align: center;
   font-size: 70px;
   position: relative;
@@ -1331,8 +1331,19 @@ dl.metric-histogram dd {
   padding: 0 5px 0 5px;
 }
 
-.dashboard .widget .loading {
+.dashboard .widget .not-available {
+  font-size: 70px;
+}
+
+.dashboard .widget .loading,
+.dashboard .widget .not-available {
+  line-height: 100px;
   text-align: center;
+}
+
+.dashboard .widget .loading .spinner,
+.dashboard .widget .not-available .spinner {
+  vertical-align: middle;
 }
 
 /* End new widgets */

--- a/javascript/src/components/widgets/Widget.jsx
+++ b/javascript/src/components/widgets/Widget.jsx
@@ -121,7 +121,9 @@ var Widget = React.createClass({
 
         var dataPromise = WidgetsStore.loadValue(this.props.dashboardId, this.props.widgetId, width);
         dataPromise.fail((jqXHR, textStatus, errorThrown) => {
+            var newResult = this.state.result === undefined ? "N/A" : this.state.result;
             this.setState({
+                result: newResult,
                 error: true,
                 errorMessage: "Error loading widget value: " + errorThrown
             });
@@ -158,6 +160,10 @@ var Widget = React.createClass({
             return <div className="loading">
                 <i className="fa fa-spin fa-3x fa-refresh spinner"></i>
             </div>;
+        }
+
+        if (this.state.result === "N/A") {
+            return <div className="not-available">{this.state.result}</div>;
         }
 
         var visualization;

--- a/javascript/src/components/widgets/Widget.jsx
+++ b/javascript/src/components/widgets/Widget.jsx
@@ -121,11 +121,12 @@ var Widget = React.createClass({
 
         var dataPromise = WidgetsStore.loadValue(this.props.dashboardId, this.props.widgetId, width);
         dataPromise.fail((jqXHR, textStatus, errorThrown) => {
+            var error = jqXHR.responseText === "" || jqXHR.responseText === "\"\"" ? errorThrown : jqXHR.responseText;
             var newResult = this.state.result === undefined ? "N/A" : this.state.result;
             this.setState({
                 result: newResult,
                 error: true,
-                errorMessage: "Error loading widget value: " + errorThrown
+                errorMessage: "Error loading widget value: " + error
             });
         });
         dataPromise.done((value) => {


### PR DESCRIPTION
- Show N/A or the last calculated value when a widget value could not be loaded
- Get a more specific error from the REST API call if available

This PR fixes #1589.