### PR TITLE
Fix back button behaviour

### DIFF
--- a/javascript/src/components/search/LegacyHistogram.jsx
+++ b/javascript/src/components/search/LegacyHistogram.jsx
@@ -24,7 +24,10 @@ var LegacyHistogram = React.createClass({
         resultHistogram.drawResultGraph();
     },
     _resolutionChanged(newResolution) {
-        return () => { SearchStore.resolution = newResolution; };
+        return (event) => {
+            event.preventDefault();
+            SearchStore.resolution = newResolution;
+        };
     },
     _getFirstHistogramValue() {
         if (SearchStore.rangeType === 'relative' && SearchStore.rangeParams.get('relative') === 0) {

--- a/javascript/src/util/URLUtils.ts
+++ b/javascript/src/util/URLUtils.ts
@@ -43,7 +43,7 @@ var URLUtils = {
     replaceHashParam(name, newValue) {
         var origHash = URLUtils.getParsedHash(window.location);
         origHash[name] = newValue;
-        window.location.hash = Qs.stringify(origHash);
+        window.location.replace(`#${Qs.stringify(origHash)}`);
     }
 };
 


### PR DESCRIPTION
When performing searches, keep only a single item in the browser history per page load. That is achieved by using `window.location.replace` instead of `window.location.hash`.

Also fix problems with back button on the sources tab. We need to change how the `SearchStore` interacts with the URL in there, but that is a story for another day :)

Fixes #1404.