### PR TITLE
Fix editing statistical funcions on field graph widgets

### DIFF
--- a/app/assets/javascripts/analyzers/analyzers/fieldcharts.js
+++ b/app/assets/javascripts/analyzers/analyzers/fieldcharts.js
@@ -175,7 +175,7 @@ $(document).ready(function () {
                 lines.push(JSON.stringify(opts));
                 $graphContainer.attr("data-lines", lines);
 
-                $(".type-description", $graphContainer).text("[" + opts.valuetype + "] " + opts.field + ", ");
+                $(".type-description", $graphContainer).text("[" + getReadableFieldChartStatisticalFunction(opts.valuetype) + "] " + opts.field + ", ");
 
                 // Do not add from time when we search in all messages
                 var from = $graphContainer.data('from') !== undefined ? data.from : undefined;
@@ -194,7 +194,7 @@ $(document).ready(function () {
                         data: data.values,
                         color: '#26ADE4',
                         gl2_query: opts.query,
-                        valuetype: opts.valuetype,
+                        valuetype: getReadableFieldChartStatisticalFunction(opts.valuetype),
                         field: opts.field
                     }]
                 });
@@ -456,7 +456,7 @@ $(document).ready(function () {
                 name: "value" + i,
                 color: lineColor,
                 gl2_query: query,
-                valuetype: series.valuetype,
+                valuetype: getReadableFieldChartStatisticalFunction(series.valuetype),
                 field: series.field
             };
 
@@ -476,3 +476,15 @@ $(document).ready(function () {
         targetChart.render();
     }
 });
+
+function getReadableFieldChartStatisticalFunction(statisticalFunction) {
+    "use strict";
+    switch (statisticalFunction) {
+        case "count":
+            return "total";
+        case "total":
+            return "sum";
+        default:
+            return statisticalFunction;
+    }
+}

--- a/javascript/src/components/search/LegacyFieldGraph.jsx
+++ b/javascript/src/components/search/LegacyFieldGraph.jsx
@@ -1,3 +1,5 @@
+/* global getReadableFieldChartStatisticalFunction */
+
 'use strict';
 
 var React = require('react');
@@ -57,12 +59,12 @@ var LegacyFieldGraph = React.createClass({
                                 <a href="#">Value</a>
 
                                 <ul className="dropdown-menu valuetype-selector">
-                                    <li><a href="#" className="selected" data-type="mean">mean</a></li>
-                                    <li><a href="#" data-type="max">maximum</a></li>
-                                    <li><a href="#" data-type="min">minimum</a></li>
-                                    <li><a href="#" data-type="total">sum</a></li>
-                                    <li><a href="#" data-type="count">total</a></li>
-                                    <li><a href="#" data-type="cardinality">cardinality</a></li>
+                                    <li><a href="#" className="selected" data-type="mean">{getReadableFieldChartStatisticalFunction('mean')}</a></li>
+                                    <li><a href="#" data-type="max">{getReadableFieldChartStatisticalFunction('max')}</a></li>
+                                    <li><a href="#" data-type="min">{getReadableFieldChartStatisticalFunction('min')}</a></li>
+                                    <li><a href="#" data-type="total">{getReadableFieldChartStatisticalFunction('total')}</a></li>
+                                    <li><a href="#" data-type="count">{getReadableFieldChartStatisticalFunction('count')}</a></li>
+                                    <li><a href="#" data-type="cardinality">{getReadableFieldChartStatisticalFunction('cardinality')}</a></li>
                                 </ul>
                             </li>
 

--- a/javascript/src/components/search/LegacyFieldGraph.jsx
+++ b/javascript/src/components/search/LegacyFieldGraph.jsx
@@ -60,8 +60,8 @@ var LegacyFieldGraph = React.createClass({
                                     <li><a href="#" className="selected" data-type="mean">mean</a></li>
                                     <li><a href="#" data-type="max">maximum</a></li>
                                     <li><a href="#" data-type="min">minimum</a></li>
-                                    <li><a href="#" data-type="total">total</a></li>
-                                    <li><a href="#" data-type="count">count</a></li>
+                                    <li><a href="#" data-type="total">sum</a></li>
+                                    <li><a href="#" data-type="count">total</a></li>
                                     <li><a href="#" data-type="cardinality">cardinality</a></li>
                                 </ul>
                             </li>

--- a/javascript/src/components/visualizations/GraphVisualization.jsx
+++ b/javascript/src/components/visualizations/GraphVisualization.jsx
@@ -1,4 +1,4 @@
-/* global graphHelper, momentHelper */
+/* global graphHelper, momentHelper, getReadableFieldChartStatisticalFunction */
 
 'use strict';
 
@@ -131,7 +131,7 @@ var GraphVisualization = React.createClass({
             formattedValue = d3.format(".2r")(d.y);
         }
 
-        var valueText = this.props.config.valuetype + " " + this.props.config.field + ": " + formattedValue + "<br>";
+        var valueText = getReadableFieldChartStatisticalFunction(this.props.config.valuetype) + " " + this.props.config.field + ": " + formattedValue + "<br>";
         var keyText = "<span class=\"date\">" + formattedKey + "</span>";
 
         return "<div class=\"datapoint-info\">" + valueText + keyText + "</div>";

--- a/javascript/src/components/widgets/WidgetCreationModal.jsx
+++ b/javascript/src/components/widgets/WidgetCreationModal.jsx
@@ -1,3 +1,5 @@
+/* global getReadableFieldChartStatisticalFunction */
+
 'use strict';
 
 var React = require('react');
@@ -82,7 +84,7 @@ var WidgetCreationModal = React.createClass({
                 break;
             case Widget.Type.FIELD_CHART:
                 if (this.props.configuration['field'] !== undefined && this.props.configuration['valuetype'] !== undefined) {
-                    title = this.props.configuration['field'] + " " + this.props.configuration['valuetype'] + " value graph";
+                    title = this.props.configuration['field'] + " " + getReadableFieldChartStatisticalFunction(this.props.configuration['valuetype']) + " value graph";
                 } else {
                     title = "field graph";
                 }

--- a/javascript/src/components/widgets/WidgetEditConfigModal.jsx
+++ b/javascript/src/components/widgets/WidgetEditConfigModal.jsx
@@ -6,6 +6,7 @@ var React = require('react');
 var Input = require('react-bootstrap').Input;
 
 var FieldStatisticsStore = require('../../stores/field-analyzers/FieldStatisticsStore');
+var FieldGraphsStore = require('../../stores/field-analyzers/FieldGraphsStore');
 var BootstrapModal = require('../bootstrap/BootstrapModal');
 
 var WidgetEditConfigModal = React.createClass({
@@ -251,10 +252,10 @@ var WidgetEditConfigModal = React.createClass({
                            defaultValue={this.state.config["valuetype"]}
                            onChange={this._onStatisticalFunctionChange("valuetype")}
                            help="Statistical function applied to the data.">
-                        {FieldStatisticsStore.FUNCTIONS.keySeq().map((statFunction) => {
+                        {FieldGraphsStore.constructor.FUNCTIONS.keySeq().map((statFunction) => {
                             return (
                                 <option key={statFunction} value={statFunction}>
-                                    {FieldStatisticsStore.FUNCTIONS.get(statFunction)}
+                                    {FieldGraphsStore.constructor.FUNCTIONS.get(statFunction)}
                                 </option>
                             );
                         })}
@@ -283,10 +284,10 @@ var WidgetEditConfigModal = React.createClass({
                                    defaultValue={series["statistical_function"]}
                                    onChange={this._onSeriesChange(seriesNo, "statistical_function")}
                                    help="Statistical function applied to the series.">
-                                {FieldStatisticsStore.FUNCTIONS.keySeq().map((statFunction) => {
+                                {FieldGraphsStore.constructor.FUNCTIONS.keySeq().map((statFunction) => {
                                     return (
                                         <option key={statFunction} value={statFunction}>
-                                            {FieldStatisticsStore.FUNCTIONS.get(statFunction)}
+                                            {FieldGraphsStore.constructor.FUNCTIONS.get(statFunction)}
                                         </option>
                                     );
                                 })}

--- a/javascript/src/stores/field-analyzers/FieldGraphsStore.ts
+++ b/javascript/src/stores/field-analyzers/FieldGraphsStore.ts
@@ -48,6 +48,15 @@ interface CreateStackedChartWidgetRequestParams {
 }
 
 class FieldGraphsStore {
+    static FUNCTIONS = Immutable.OrderedMap<string, string>({
+        count: 'Total',
+        mean: 'Mean',
+        min: 'Minimum',
+        max: 'Maximum',
+        total: 'Sum',
+        cardinality: 'Cardinality',
+    });
+
     private renderedGraphs: Immutable.Set<string>;
     private _fieldGraphs: Immutable.Map<string, Object>;
     private _stackedGraphs: Immutable.Map<string, Immutable.Set<string>>;


### PR DESCRIPTION
Statistical value widgets and field graph widgets support a slightly different subset of statistical functions, and use some different names in the data returned from the server. These changes take care of only offering the supported functions on the edit widget form. Additionally, they take care of abstracting our naming inconsistencies from the user.

Fixes #1604, and should be merged into 1.2 as well as master.
