### PR TITLE
Replace problematic characters in bootstrap accordion IDs with '-'

### DIFF
--- a/javascript/src/components/bootstrap/BootstrapAccordionGroup.jsx
+++ b/javascript/src/components/bootstrap/BootstrapAccordionGroup.jsx
@@ -9,7 +9,7 @@ var BootstrapAccordionGroup = React.createClass({
 
         if (this.props.name) {
             name = this.props.name;
-            id = name.replace(/ /g, "_").toLowerCase();
+            id = name.replace(/[^0-9a-zA-Z]/g, "-").toLowerCase();
         }
 
         return (


### PR DESCRIPTION
Replace all non-numeric and non-alphabetic characters in IDs being used in URI anchors with '-'.

Refs Jerrison777/Graylog-MWG-Contentpack#2