### PR TITLE
Bump to Typescript 1.6, employing ts-loader

### DIFF
--- a/javascript/npm-shrinkwrap.json
+++ b/javascript/npm-shrinkwrap.json
@@ -2,50 +2,6 @@
   "name": "graylog-web-interface",
   "version": "1.3.0-SNAPSHOT",
   "dependencies": {
-    "awesome-typescript-loader": {
-      "version": "0.9.3",
-      "from": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-0.9.3.tgz",
-      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-0.9.3.tgz",
-      "dependencies": {
-        "bluebird": {
-          "version": "2.9.34",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
-        },
-        "loader-utils": {
-          "version": "0.2.11",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.11.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.11.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-        },
-        "colors": {
-          "version": "1.1.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-        }
-      }
-    },
     "babel-core": {
       "version": "5.8.22",
       "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.22.tgz",
@@ -4217,9 +4173,9 @@
       }
     },
     "typescript": {
-      "version": "1.5.3",
-      "from": "https://registry.npmjs.org/typescript/-/typescript-1.5.3.tgz",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.5.3.tgz"
+      "version": "1.6.2",
+      "from": "https://registry.npmjs.org/typescript/-/typescript-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.6.2.tgz"
     },
     "webpack": {
       "version": "1.11.0",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0-SNAPSHOT",
   "description": "Graylog Web Interface",
   "author": "torch",
-  "license": "GPL",
+  "license": "GPL-3.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/graylog2/graylog2-web-interface.git"
@@ -33,7 +33,7 @@
     "sockjs-client": "1.0.x"
   },
   "devDependencies": {
-    "babel-core": "^5.8.12",
+    "babel-core": "^5.8.25",
     "babel-eslint": "^4.0.5",
     "babel-loader": "^5.3.2",
     "clean-webpack-plugin": "^0.1.3",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -4,6 +4,11 @@
   "description": "Graylog Web Interface",
   "author": "torch",
   "license": "GPL",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/graylog2/graylog2-web-interface.git"
+  },
+  "readme": "../README.md",
   "scripts": {
     "build": "./node_modules/.bin/webpack",
     "test": "./node_modules/karma/bin/karma start karma.ci.conf.js",
@@ -28,7 +33,6 @@
     "sockjs-client": "1.0.x"
   },
   "devDependencies": {
-    "awesome-typescript-loader": "^0.9.2",
     "babel-core": "^5.8.12",
     "babel-eslint": "^4.0.5",
     "babel-loader": "^5.3.2",
@@ -50,7 +54,8 @@
     "karma-webpack": "*",
     "phantomjs": ">=1.9",
     "react-hot-loader": "^1.2.8",
-    "typescript": "^1.5.3",
+    "ts-loader": "^0.5.5",
+    "typescript": "^1.6.2",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1"
   }

--- a/javascript/src/stores/field-analyzers/FieldGraphsStore.ts
+++ b/javascript/src/stores/field-analyzers/FieldGraphsStore.ts
@@ -2,12 +2,9 @@
 
 'use strict';
 
-declare
-var $: any;
-declare
-var store: any;
-declare
-var generateId: ()=>string;
+declare var $: any;
+declare var store: any;
+declare var generateId: ()=>string;
 
 import Immutable = require('immutable');
 

--- a/javascript/src/stores/field-analyzers/FieldQuickValuesStore.ts
+++ b/javascript/src/stores/field-analyzers/FieldQuickValuesStore.ts
@@ -2,10 +2,8 @@
 
 'use strict';
 
-declare
-var $: any;
-declare
-var jsRoutes: any;
+declare var $: any;
+declare var jsRoutes: any;
 
 import SearchStore = require('../search/SearchStore');
 import UserNotification = require('../../util/UserNotification');

--- a/javascript/src/stores/search/SearchStore.ts
+++ b/javascript/src/stores/search/SearchStore.ts
@@ -4,8 +4,7 @@
 
 'use strict';
 
-declare
-var jsRoutes: any;
+declare var jsRoutes: any;
 
 import Immutable = require('immutable');
 var Qs = require('qs');

--- a/javascript/src/stores/widgets/WidgetsStore.ts
+++ b/javascript/src/stores/widgets/WidgetsStore.ts
@@ -2,8 +2,7 @@
 
 'use strict';
 
-declare
-var jsRoutes: any;
+declare var jsRoutes: any;
 
 import UserNotification = require("../../util/UserNotification");
 

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions" : {
-    "module" : "system",
+    "target": "es5",
     "sourceMap" : true
-  }
+  },
+  "files": []
 }

--- a/javascript/webpack.shared.config.js
+++ b/javascript/webpack.shared.config.js
@@ -14,7 +14,7 @@ var webpackConfig = {
         loaders: [
             { test: /\.json$/, loader: 'json-loader' },
             { test: /\.js(x)?$/, loaders: ['react-hot', 'babel-loader?stage=0'], exclude: /node_modules|\.node_cache/ },
-            { test: /\.ts$/, loader: 'awesome-typescript-loader?emitRequireType=false&library=es6', exclude: /node_modules|\.node_cache/ }
+            { test: /\.ts$/, loader: 'babel-loader!ts-loader', exclude: /node_modules|\.node_cache/ }
         ]
     },
     resolve: {


### PR DESCRIPTION
This PR bumps the used typescript compiler to version 1.6.2 and replaces the awesome-typescript-loader (which is a fork of typescript-loader) with the now much more commonly used and supposedly better maintained ts-loader.
