### PR TITLE
Allow negative and empty values on numeric fields

### DIFF
--- a/javascript/src/components/configurationforms/NumberField.jsx
+++ b/javascript/src/components/configurationforms/NumberField.jsx
@@ -3,20 +3,11 @@
 var React = require('react');
 var FieldHelpers = require('./FieldHelpers');
 
+var NumberUtils = require('util/NumberUtils');
+
 var NumberField = React.createClass({
     MAX_SAFE_INTEGER: (Number.MAX_SAFE_INTEGER !== undefined ? Number.MAX_SAFE_INTEGER : Math.pow(2,53)-1),
     MIN_SAFE_INTEGER: (Number.MIN_SAFE_INTEGER !== undefined ? Number.MIN_SAFE_INTEGER : -1*(Math.pow(2,53)-1)),
-    getInitialState() {
-        return {
-            typeName: this.props.typeName,
-            field: this.props.field,
-            title: this.props.title,
-            value: this.props.value
-        };
-    },
-    componentWillReceiveProps(props) {
-        this.setState(props);
-    },
     _getDefaultValidationSpecs() {
         return {min: this.MIN_SAFE_INTEGER, max: this.MAX_SAFE_INTEGER};
     },
@@ -39,16 +30,15 @@ var NumberField = React.createClass({
         }
     },
     handleChange(evt) {
-        const numericValue = Number(evt.target.value);
-        this.props.onChange(this.state.title, numericValue);
-        this.setState({value: numericValue});
+        const numericValue = NumberUtils.isNumber(evt.target.value) ? Number(evt.target.value) : undefined;
+        this.props.onChange(this.props.title, numericValue);
     },
     render() {
-        var typeName = this.state.typeName;
-        var field = this.state.field;
+        var typeName = this.props.typeName;
+        var field = this.props.field;
         var isRequired = !field.is_optional;
         var validationSpecs = this.validationSpec(field);
-        var defaultValue = field.default_value;
+        var fieldValue = this.props.value !== undefined ? this.props.value : field.default_value;
 
         return (
             <div className="form-group">
@@ -56,9 +46,10 @@ var NumberField = React.createClass({
                     {field.human_name}
                     {FieldHelpers.optionalMarker(field)}
                 </label>
-                <input id={field.title} type="number" required={isRequired} onChange={this.handleChange} value={this.state.value}
-                       defaultValue={defaultValue} className="input-xlarge validatable form-control"
-                       {...validationSpecs}/>
+
+                <input id={field.title} type="number" required={isRequired} onChange={this.handleChange}
+                       defaultValue={fieldValue} className="input-xlarge validatable form-control"
+                       {...validationSpecs} autoFocus={this.props.autoFocus} />
 
                 <p className="help-block">{field.description}</p>
             </div>

--- a/javascript/src/util/NumberUtils.ts
+++ b/javascript/src/util/NumberUtils.ts
@@ -41,6 +41,9 @@ var NumberUtils = {
             return percentage;
         }
     },
+    isNumber(possibleNumber) {
+        return possibleNumber !== "" && !isNaN(possibleNumber);
+    },
 };
 
 export = NumberUtils;


### PR DESCRIPTION
On entities using the `ConfigurationForm` component, use `undefined` as value for empty or non-numeric values on a `NumericField`.
- Numeric values are still converted into a number, avoiding #1596
- Non-numeric values will raise an error when the browser validates
  the input
- Empty values will be treated as default values in optional input
  fields, or will raise an error otherwise

These changes should also be merged into master.

Fixes #1628.
