### PR TITLE
Do not collapse white spaces on extractor example

### DIFF
--- a/app/assets/stylesheets/graylog2.less
+++ b/app/assets/stylesheets/graylog2.less
@@ -594,6 +594,7 @@ s
   margin-bottom: 5px;
   font-family: monospace;
   font-size: 14px;
+  white-space: pre-wrap;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
On the create or edit extractor page, do not collapse message example white spaces, as they may be relevant.

The change needs to be merged into to 1.3 as well. I will take care of merging it into master, as it needs some additional work.

Fixes #1650.
