### PR TITLE
Optimize fetching index information on System/Indices page

### DIFF
--- a/app/controllers/IndicesController.java
+++ b/app/controllers/IndicesController.java
@@ -76,6 +76,7 @@ public class IndicesController extends AuthenticatedController {
                     currentUser(),
                     bc,
                     indexService.all(),
+                    indexService.allIndicesInfo(),
                     closedIndices.indices,
                     reopenedSet,
                     clusterHealth,

--- a/app/controllers/api/IndicesApiController.java
+++ b/app/controllers/api/IndicesApiController.java
@@ -102,8 +102,7 @@ public class IndicesApiController extends AuthenticatedController {
                 return notFound();
             }
             final String currentTarget = indexService.getDeflectorInfo().currentTarget;
-            return ok(views.html.partials.indices.index_info.render(currentTarget, index));
-
+            return ok(views.html.partials.indices.index_info.render(currentTarget, index, indexService.indexInfo(indexName)));
         } catch (APIException | IOException e) {
             return internalServerError();
         }

--- a/app/views/partials/indices/index_info.scala.html
+++ b/app/views/partials/indices/index_info.scala.html
@@ -1,4 +1,6 @@
-@(deflectorTarget: String, index: org.graylog2.restclient.models.Index)
+@import org.graylog2.rest.models.system.indexer.responses.IndexInfo
+@import org.graylog2.restclient.models.Index
+@(deflectorTarget: String, index: Index, indexInfo: IndexInfo)
 
 @import views.helpers.DateHelper
 
@@ -8,23 +10,23 @@
         in @(index.getRange.getCalculationTookMs)ms.
     }
 
-    @if(index.getInfo == null) {
+    @if(indexInfo == null) {
         <div class="alert alert-info"><i class="fa fa-info-circle"></i> Index information is not available at the moment, please try again later.</div>
     } else {
-        @index.getInfo.getSegments segments,
-        @index.getInfo.getOpenSearchContexts open search contexts,
-        @index.getInfo.getDocuments.deleted deleted messages
+        @indexInfo.primaryShards.segments segments,
+        @indexInfo.primaryShards.openSearchContexts open search contexts,
+        @indexInfo.primaryShards.documents.deleted deleted messages
 
         <div class="row" style="margin-bottom: 10px;">
-            @views.html.system.indices.partials.shard_meters.render("Primary shard operations", index.getInfo.getPrimaryShards)
-            @views.html.system.indices.partials.shard_meters.render("Total shard operations", index.getInfo.getAllShards)
+            @views.html.system.indices.partials.index_stats.render("Primary shard operations", indexInfo.primaryShards())
+            @views.html.system.indices.partials.index_stats.render("Total shard operations", indexInfo.allShards())
         </div>
 
         <div class="shard-routing">
             <h3>Shard routing</h3>
 
             <ul class="shards">
-            @for(route <- index.getInfo.getShardRouting.sortBy(_.id)) {
+            @for(route <- indexInfo.routing.sortBy(_.id)) {
                 <li class="shard shard-@route.state
                     @if(route.primary) {
                         shard-primary

--- a/app/views/system/indices/index.scala.html
+++ b/app/views/system/indices/index.scala.html
@@ -1,9 +1,11 @@
 @import org.joda.time.DateTime
+@import org.graylog2.rest.models.system.indexer.responses.IndexInfo
 @(currentUser: org.graylog2.restclient.models.User,
         breadcrumbs: lib.BreadcrumbList,
-        indices: List[org.graylog2.restclient.models.Index],
-        closedIndices: List[String],
-        reopenedSet: Set[String],
+        indices: java.util.List[org.graylog2.restclient.models.Index],
+        indicesInfo : java.util.Map[String, IndexInfo],
+        closedIndices: java.util.List[String],
+        reopenedSet: java.util.Set[String],
         clusterHealth: org.graylog2.restclient.models.ESClusterHealth,
         deflectorTarget: String,
         deflectorConfig: org.graylog2.restclient.models.api.responses.system.indices.DeflectorConfigResponse)
@@ -93,7 +95,7 @@
     </div>
 
     @* We may not have deflector index information if the deflector is cycled and the index ranges are being rebuilt. *@
-    @if(indices.find(_.getName == deflectorTarget) == None) {
+    @if(!indices.exists(_.getName == deflectorTarget)) {
         <div class="row index-description content">
             <div class="col-md-12">
                 <h3>
@@ -111,18 +113,19 @@
     }
 
     @for(index <- indices.sortWith(_.getNumber > _.getNumber)) {
-        <div class="row index-description content">
-            <div class="col-md-12">
-                <h2>
-                    @if(index.getName.equals(deflectorTarget)) {
-                        <i class="fa fa-bolt" title="Write-active index"></i>
-                    }
+        @defining(indicesInfo.get(index.getName)) { indexInfo =>
+            <div class="row index-description content">
+                <div class="col-md-12">
+                    <h2>
+                        @if(index.getName.equals(deflectorTarget)) {
+                            <i class="fa fa-bolt" title="Write-active index"></i>
+                        }
 
-                    @index.getName
+                        @index.getName
 
-                    @if(reopenedSet.contains(index.getName)) {
-                        <i class="fa fa-retweet" title="Reopened index"></i>
-                    }
+                        @if(reopenedSet.contains(index.getName)) {
+                            <i class="fa fa-retweet" title="Reopened index"></i>
+                        }
 
                     <small>
                         @if(index.getName.equals(deflectorTarget)) {
@@ -139,28 +142,31 @@
                             }
                         }
 
-                        @if(index != null && index.getInfo != null) {
-                            (@Tools.byteToHuman(index.getInfo.getStoreSizeBytes) /
-                            <span class="number-format" data-format="0,0">@index.getInfo.getDocuments.count</span> messages)
+                        @if(index != null && indexInfo != null) {
+                            (@Tools.byteToHuman(indexInfo.primaryShards.storeSizeBytes) /
+                            <span class="number-format" data-format="0,0">@indexInfo.primaryShards.documents.count</span>
+                            messages)
                         }
 
                         @if(!index.getName.equals(deflectorTarget)) {
-                            <a href="#" class="index-details" data-index-name="@index.getName"><i class="fa fa-caret-right"></i>  Load Details / Actions</a>
+                            <a href="#" class="index-details" data-index-name="@index.getName"><i class="fa fa-caret-right"></i>
+                                Load Details / Actions</a>
                         }
                     </small>
-                </h2>
+                    </h2>
 
-                <div class="index-info-holder"
-                    @if(!index.getName.equals(deflectorTarget)) {
-                        style="display: none;"
-                        }
-                >
-                @if(index.getName.equals(deflectorTarget)) {
-                    @views.html.partials.indices.index_info.render(deflectorTarget, index)
-                }
+                    <div class="index-info-holder"
+                        @if(!index.getName.equals(deflectorTarget)) {
+                            style="display: none;"
+                            }
+                    >
+                    @if(index.getName.equals(deflectorTarget)) {
+                        @views.html.partials.indices.index_info.render(deflectorTarget, index, indexInfo)
+                    }
+                    </div>
                 </div>
             </div>
-        </div>
+        }
     }
 
 }

--- a/app/views/system/indices/partials/index_stats.scala.html
+++ b/app/views/system/indices/partials/index_stats.scala.html
@@ -1,0 +1,21 @@
+@import org.graylog2.rest.models.system.indexer.responses.IndexStats
+@(title: String, indexStats: IndexStats)
+<div class="shard-meters col-md-4">
+    <h3 style="display: inline;">@title</h3>
+    <dl>
+        <dt>Index:</dt>
+        <dd>@views.html.system.indices.partials.time_and_total_stats.render(indexStats.index())</dd>
+        <dt>Flush:</dt>
+        <dd>@views.html.system.indices.partials.time_and_total_stats.render(indexStats.flush())</dd>
+        <dt>Merge:</dt>
+        <dd>@views.html.system.indices.partials.time_and_total_stats.render(indexStats.merge())</dd>
+        <dt>Query:</dt>
+        <dd>@views.html.system.indices.partials.time_and_total_stats.render(indexStats.searchQuery())</dd>
+        <dt>Fetch:</dt>
+        <dd>@views.html.system.indices.partials.time_and_total_stats.render(indexStats.searchFetch())</dd>
+        <dt>Get:</dt>
+        <dd>@views.html.system.indices.partials.time_and_total_stats.render(indexStats.get())</dd>
+        <dt>Refresh:</dt>
+        <dd>@views.html.system.indices.partials.time_and_total_stats.render(indexStats.refresh())</dd>
+    </dl>
+</div>

--- a/app/views/system/indices/partials/time_and_total_stats.scala.html
+++ b/app/views/system/indices/partials/time_and_total_stats.scala.html
@@ -1,0 +1,6 @@
+@import org.graylog2.rest.models.system.indexer.responses.IndexStats
+@(t: IndexStats.TimeAndTotalStats)
+<span class="number-format" data-format="0,0">@t.total</span> ops
+@if(t.total > 0) {
+    (took <span class="moment-humanize" data-unit="seconds" title="@(t.timeSeconds)s">@t.timeSeconds</span>)
+}


### PR DESCRIPTION
Instead of fetching index information multiple times per index, the new implementation fetches the information in bulk and pulls the details out of that larger data structure.

This should fix the timeouts of the System/Indices page on setups with a large number of indices and/or a slow Elasticsearch cluster.

Depends on Graylog2/graylog2-server#1539.