### PR TITLE
Fixes link to the documentation

### DIFF
--- a/javascript/src/util/DocsHelper.ts
+++ b/javascript/src/util/DocsHelper.ts
@@ -27,7 +27,7 @@ class DocsHelper {
     STANDARD_DATE_CONVERTER: 'extractors.html#the-standard-date-converter',
     STREAMS: 'streams.html',
     STREAM_PROCESSING_RUNTIME_LIMITS: 'streams.html#stream-processing-runtime-limits',
-    USERS_ROLES: 'users_roles.html',
+    USERS_ROLES: 'users_and_roles.html',
     WELCOME: '', // Welcome page to the documentation
   };
   DOCS_URL: string = 'http://docs.graylog.org/en/';


### PR DESCRIPTION
Old link: http://docs.graylog.org/en/1.2/pages/users_roles.html
New link: http://docs.graylog.org/en/1.2/pages/users_and_roles.html