### PR TITLE
Do not double escape full_message field

### DIFF
--- a/app/assets/javascripts/extractors.js
+++ b/app/assets/javascripts/extractors.js
@@ -20,8 +20,16 @@ $(document).ready(function () {
 
         var wizard = $(".xtrc-wizard");
         $(".xtrc-wizard-field", wizard).html(field);
-        $(".xtrc-wizard-example", wizard).html(htmlEscape(value));
+        var escapedValue;
 
+        // full_message field is already escaped, no need to do that again
+        if (field === 'full_message') {
+            escapedValue = value;
+        } else {
+            escapedValue = htmlEscape(value);
+        }
+
+        $(".xtrc-wizard-example", wizard).html(escapedValue);
         $("input[name=field]", wizard).val(field);
         $("input[name=example_id]", wizard).val(messageId);
         $("input[name=example_index]", wizard).val(messageIndex);

--- a/app/assets/javascripts/messageloader.js
+++ b/app/assets/javascripts/messageloader.js
@@ -97,11 +97,19 @@
 
             for (var field in msg) {
                 var newElems = placeHolders.clone();
-                var i = 0;
                 newElems.each( function(c, elem) {
-                    var newElem = elem.outerHTML.replace(/\{\{field\}\}/g, field)
-                        .replace(/\{\{value\}\}/g, htmlEscape(msg[field]))
-                        .replace(/\{\{raw-value\}\}/g, htmlEscape(msg[field]).replace(/"/g, "&quot;"));
+                    var newElem;
+
+                    // Full message was already escaped in the web interface, no need to do that again on the preview
+                    if (elem.localName === "dd" && field === "full_message") {
+                        newElem = elem.outerHTML.replace(/\{\{field\}\}/g, field)
+                          .replace(/\{\{value\}\}/g, msg[field])
+                          .replace(/\{\{raw-value\}\}/g, msg[field].replace(/"/g, "&quot;"));
+                    } else {
+                        newElem = elem.outerHTML.replace(/\{\{field\}\}/g, field)
+                          .replace(/\{\{value\}\}/g, htmlEscape(msg[field]))
+                          .replace(/\{\{raw-value\}\}/g, htmlEscape(msg[field]).replace(/"/g, "&quot;"));
+                    }
                     var newElem = $( newElem ).removeAttr("data-occurrence");
                     newElem.appendTo(list);
                 });


### PR DESCRIPTION
The `full_message` formatted field is already escaped on the server, so we avoid escaping it again in the Javascript code.

Depends on https://github.com/Graylog2/graylog2-server/pull/1569, and both changes fix #1686
