### PR TITLE
Remove state from BooleanField component

### DIFF
--- a/javascript/src/components/configurationforms/BooleanField.jsx
+++ b/javascript/src/components/configurationforms/BooleanField.jsx
@@ -9,22 +9,11 @@ const BooleanField = React.createClass({
     onChange: PropTypes.func.isRequired,
     value: PropTypes.any,
   },
-  getInitialState() {
-    return {
-      typeName: this.props.typeName,
-      field: this.props.field,
-      title: this.props.title,
-      value: (this.props.value === undefined ? this.props.field.default_value : this.props.value),
-    };
-  },
-  componentWillReceiveProps(props) {
-    this.setState(props);
-  },
   render() {
-    const field = this.state.field;
-    const typeName = this.state.typeName;
-    const title = this.state.title;
-    const value = this.state.value;
+    const field = this.props.field;
+    const typeName = this.props.typeName;
+    const title = this.props.title;
+    const value = this._getEffectiveValue();
     return (
       <div className="form-group">
         <div className="checkbox">
@@ -44,10 +33,13 @@ const BooleanField = React.createClass({
       </div>
     );
   },
+  _getEffectiveValue() {
+    return (this.props.value === undefined ? this.props.field.default_value : this.props.value);
+  },
   handleChange() {
-    const newValue = !this.state.value;
+    const newValue = !this._getEffectiveValue();
     this.setState({value: newValue});
-    this.props.onChange(this.state.title, newValue);
+    this.props.onChange(this.props.title, newValue);
   },
 });
 

--- a/javascript/src/components/configurationforms/BooleanField.jsx
+++ b/javascript/src/components/configurationforms/BooleanField.jsx
@@ -1,48 +1,53 @@
-'use strict';
+import React, {PropTypes} from 'react';
+import FieldHelpers from './FieldHelpers';
 
-var React = require('react');
-var FieldHelpers = require('./FieldHelpers');
+const BooleanField = React.createClass({
+  propTypes: {
+    typeName: PropTypes.string.isRequired,
+    field: PropTypes.object.isRequired,
+    title: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    value: PropTypes.any,
+  },
+  getInitialState() {
+    return {
+      typeName: this.props.typeName,
+      field: this.props.field,
+      title: this.props.title,
+      value: (this.props.value === undefined ? this.props.field.default_value : this.props.value),
+    };
+  },
+  componentWillReceiveProps(props) {
+    this.setState(props);
+  },
+  render() {
+    const field = this.state.field;
+    const typeName = this.state.typeName;
+    const value = this.state.value;
+    return (
+      <div className="form-group">
+        <div className="checkbox">
+          <label>
+            <input id={typeName + '-' + field.title}
+                   type="checkbox"
+                   checked={value}
+                   name={`configuration[${field.title}]`}
+                   onChange={this.handleChange}/>
 
-var BooleanField = React.createClass({
-    getInitialState() {
-        return {
-            typeName: this.props.typeName,
-            field: this.props.field,
-            title: this.props.title,
-            value: (this.props.value === undefined ? this.props.field.default_value : this.props.value)
-        };
-    },
-    componentWillReceiveProps(props) {
-        this.setState(props);
-    },
-    handleChange(evt) {
-        var newValue = !this.state.value;
-        this.setState({value: newValue});
-        this.props.onChange(this.state.title, newValue);
-    },
-    render() {
-        var field = this.state.field;
-        var typeName = this.state.typeName;
-        var value = this.state.value;
-        return (
-            <div className="form-group">
-                <div className="checkbox">
-                    <label>
-                        <input id={typeName + "-" + field.title}
-                            type="checkbox"
-                            checked={value}
-                            name={"configuration[" + field.title + "]"}
-                            onChange={this.handleChange} />
+            {field.human_name}
 
-                            {field.human_name}
-
-                            {FieldHelpers.optionalMarker(field)}
-                    </label>
-                </div>
-                <p className="help-block">{field.description}</p>
-            </div>
-        );
-    }
+            {FieldHelpers.optionalMarker(field)}
+          </label>
+        </div>
+        <p className="help-block">{field.description}</p>
+      </div>
+    );
+  },
+  handleChange() {
+    const newValue = !this.state.value;
+    this.setState({value: newValue});
+    this.props.onChange(this.state.title, newValue);
+  },
 });
 
-module.exports = BooleanField;
+export default BooleanField;

--- a/javascript/src/components/configurationforms/BooleanField.jsx
+++ b/javascript/src/components/configurationforms/BooleanField.jsx
@@ -23,15 +23,16 @@ const BooleanField = React.createClass({
   render() {
     const field = this.state.field;
     const typeName = this.state.typeName;
+    const title = this.state.title;
     const value = this.state.value;
     return (
       <div className="form-group">
         <div className="checkbox">
           <label>
-            <input id={typeName + '-' + field.title}
+            <input id={typeName + '-' + title}
                    type="checkbox"
                    checked={value}
-                   name={`configuration[${field.title}]`}
+                   name={`configuration[${title}]`}
                    onChange={this.handleChange}/>
 
             {field.human_name}


### PR DESCRIPTION
Changing the `props` that `BooleanField` was receiving was modifying the default value if it didn't change, causing the checkbox to uncheck if any other field in the form was modified.

My suspicion is that this is behind issue #1676.