### PR TITLE
Avoid deletion of group mappings when updating LDAP settings

### DIFF
--- a/app/controllers/LdapController.java
+++ b/app/controllers/LdapController.java
@@ -100,8 +100,9 @@ public class LdapController extends AuthenticatedController {
 
         final List<RoleResponse> roles = Lists.newArrayList(rolesService.loadAll());
         final Set<String> selectedAdditionalGroups = ldapSettings != null && ldapSettings.getAdditionalDefaultGroups() != null ? ldapSettings.getAdditionalDefaultGroups() : Collections.<String>emptySet();
+        final Map<String, String> groupMapping = ldapSettings == null ? Collections.<String, String>emptyMap() : ldapSettings.getGroupMapping();
         return ok(views.html.system.ldap.index.render(currentUser(), breadcrumbs(), ldapSettingsForm, roles,
-                                                      selectedAdditionalGroups));
+                                                      selectedAdditionalGroups, groupMapping));
     }
     public Result groups() {
         final LdapSettings ldapSettings = ldapSettingsService.load();
@@ -179,7 +180,7 @@ public class LdapController extends AuthenticatedController {
             final List<RoleResponse> roles = Lists.newArrayList(rolesService.loadAll());
             final Set<String> additionalGroupsAsSet = safeAdditionalGroupsAsSet(form.get().additionalDefaultGroups);
             return badRequest(views.html.system.ldap.index.render(currentUser(), breadcrumbs(), form, roles,
-                                                                  additionalGroupsAsSet));
+                                                                  additionalGroupsAsSet, form.get().groupMapping));
         }
         final LdapSettingsRequest2 formValue = form.get();
         final LdapSettingsRequest request = new LdapSettingsRequest();

--- a/app/views/system/ldap/index.scala.html
+++ b/app/views/system/ldap/index.scala.html
@@ -2,7 +2,7 @@
         breadcrumbs: lib.BreadcrumbList,
         ldapForm: Form[controllers.LdapController.LdapSettingsRequest2],
         roles: List[org.graylog2.rest.models.roles.responses.RoleResponse],
-        selectedAdditionalGroups: Set[String])
+        selectedAdditionalGroups: Set[String], groupMapping: Map[String, String])
 
 @main("LDAP Settings", null, "", currentUser, false) {
 
@@ -25,6 +25,10 @@
     <div class="row content">
         <div class="col-lg-8">
         @helper.form(action = routes.LdapController.saveLdapSettings(), 'class -> "form-horizontal", 'id -> "ldap-settings") {
+            @for((k, v) <- groupMapping) {
+                <input type="hidden" name="groupMapping[@k]" value="@v"/>
+            }
+
             <div class="form-group">
                 <div class="col-sm-offset-3 col-sm-9">
                     <div class="checkbox">


### PR DESCRIPTION
Put the current group mapping into hidden fields in the form to make
sure they are preserved.

Fixes Graylog2/graylog2-server#1513
